### PR TITLE
Add initial Prisma schema

### DIFF
--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,3 +11,192 @@ generator client {
 datasource db {
   provider = "postgresql"
 }
+
+model User {
+  id                 Int       @id @default(autoincrement())
+  username           String    @unique
+  email              String    @unique
+  password_hash      String
+  avatar_url         String?
+  bio                String?
+  two_factor_enabled Boolean   @default(false)
+  created_at         DateTime  @default(now())
+  edited_at          DateTime?
+
+  owned_teams              Team[]            @relation("TeamOwned")
+  team_users               TeamUser[]
+  team_messages            TeamMessage[]
+  team_join_requests       TeamJoinRequest[]
+  team_invites             TeamInvite[]
+  tasks                    Task[]
+  task_users               TaskUser[]
+  files                    File[]
+  sent_friend_requests     FriendRequest[]   @relation("SentFriendRequests")
+  received_friend_requests FriendRequest[]   @relation("ReceivedFriendRequests")
+  first_friend             Friendship[]      @relation("FirstFriend")
+  second_friend            Friendship[]      @relation("SecondFriend")
+  sent_direct_messages     DirectMessage[]   @relation("SentDirectMessages")
+  received_direct_messages DirectMessage[]   @relation("ReceivedDirectMessages")
+  triggered_notifications  Notification[]    @relation("TriggeredNotifications")
+  received_notifications   Notification[]    @relation("ReceivedNotifications")
+}
+
+model Team {
+  id             Int       @id @default(autoincrement())
+  name           String    @unique
+  owner_id       Int
+  max_users      Int
+  about          String?
+  tags           String?
+  status_ongoing Boolean   @default(true)
+  created_at     DateTime  @default(now())
+  edited_at      DateTime?
+
+  owner              User              @relation("TeamOwned", fields: [owner_id], references: [id])
+  team_users         TeamUser[]
+  team_messages      TeamMessage[]
+  team_invites       TeamInvite[]
+  team_join_requests TeamJoinRequest[]
+  tasks              Task[]
+  files              File[]
+}
+
+model TeamUser {
+  id        Int      @id @default(autoincrement())
+  user_id   Int
+  team_id   Int
+  joined_at DateTime @default(now())
+
+  user User @relation(fields: [user_id], references: [id])
+  team Team @relation(fields: [team_id], references: [id])
+
+  @@unique([user_id, team_id])
+}
+
+model TeamInvite {
+  id         Int      @id @default(autoincrement())
+  team_id    Int
+  user_id    Int
+  status     String
+  created_at DateTime @default(now())
+
+  team Team @relation(fields: [team_id], references: [id])
+  user User @relation(fields: [user_id], references: [id])
+}
+
+model TeamJoinRequest {
+  id         Int      @id @default(autoincrement())
+  user_id    Int
+  team_id    Int
+  status     String
+  created_at DateTime @default(now())
+
+  user User @relation(fields: [user_id], references: [id])
+  team Team @relation(fields: [team_id], references: [id])
+}
+
+model FriendRequest {
+  id          Int       @id @default(autoincrement())
+  sender_id   Int
+  receiver_id Int
+  status      String    @default("pending")
+  sent_at     DateTime  @default(now())
+  accepted_at DateTime?
+
+  sender   User @relation("SentFriendRequests", fields: [sender_id], references: [id])
+  receiver User @relation("ReceivedFriendRequests", fields: [receiver_id], references: [id])
+}
+
+model Friendship {
+  id             Int      @id @default(autoincrement())
+  user_id_first  Int
+  user_id_second Int
+  friends_since  DateTime @default(now())
+
+  user_first  User @relation("FirstFriend", fields: [user_id_first], references: [id])
+  user_second User @relation("SecondFriend", fields: [user_id_second], references: [id])
+
+  @@unique([user_id_first, user_id_second])
+}
+
+model DirectMessage {
+  id          Int      @id @default(autoincrement())
+  sender_id   Int
+  receiver_id Int
+  content     String
+  status_read Boolean  @default(false)
+  sent_at     DateTime @default(now())
+
+  sender   User @relation("SentDirectMessages", fields: [sender_id], references: [id])
+  receiver User @relation("ReceivedDirectMessages", fields: [receiver_id], references: [id])
+}
+
+model TeamMessage {
+  id        Int      @id @default(autoincrement())
+  sender_id Int
+  team_id   Int
+  content   String
+  sent_at   DateTime @default(now())
+
+  sender User @relation(fields: [sender_id], references: [id])
+  team   Team @relation(fields: [team_id], references: [id])
+}
+
+model Task {
+  id          Int       @id @default(autoincrement())
+  team_id     Int
+  creator_id  Int
+  title       String
+  description String?
+  status      String    @default("open")
+  created_at  DateTime  @default(now())
+  finished_at DateTime?
+
+  creator    User       @relation(fields: [creator_id], references: [id])
+  team       Team       @relation(fields: [team_id], references: [id])
+  files      File[]
+  task_users TaskUser[]
+}
+
+model TaskUser {
+  id          Int      @id @default(autoincrement())
+  user_id     Int
+  task_id     Int
+  assigned_at DateTime @default(now())
+
+  user User @relation(fields: [user_id], references: [id])
+  task Task @relation(fields: [task_id], references: [id])
+
+  @@unique([user_id, task_id])
+}
+
+model Notification {
+  id               Int      @id @default(autoincrement())
+  user_id_trigger  Int?
+  user_id_receiver Int
+  type             String
+  entity_id        Int?
+  entity_type      String?
+  content          String?
+  status_read      Boolean  @default(false)
+  created_at       DateTime @default(now())
+
+  user_trigger  User? @relation("TriggeredNotifications", fields: [user_id_trigger], references: [id])
+  user_receiver User  @relation("ReceivedNotifications", fields: [user_id_receiver], references: [id])
+}
+
+model File {
+  id          Int      @id @default(autoincrement())
+  uploader_id Int
+  team_id     Int?
+  task_id     Int?
+  file_name   String
+  file_url    String
+  file_type   String?
+  file_size   Int?
+  created_at  DateTime @default(now())
+
+  uploader User  @relation(fields: [uploader_id], references: [id])
+  team     Team? @relation(fields: [team_id], references: [id])
+  task     Task? @relation(fields: [task_id], references: [id])
+}


### PR DESCRIPTION
This PR adds the initial Prisma schema based on the approved DB design.

Included:
- models for all approved entities
- relationships between models
- required/optional fields
- default values
- unique constraints for `TeamUser`, `TaskUser`, and `Friendship`

Validated with:
- `npx prisma format`
- `npx prisma validate`