### PR TITLE
Fixed files system issue

### DIFF
--- a/project/backend/application/src/tasks/tasks.service.ts
+++ b/project/backend/application/src/tasks/tasks.service.ts
@@ -2,6 +2,7 @@ import { prisma } from "../prisma.js";
 import { AppError } from "../utils/AppError.js";
 import type { CreateTaskDTO } from "./tasks.types.js";
 import fs from "fs";
+import path from 'path';
 
 export const createTask = async ( creatorId: number, teamId: number, data: CreateTaskDTO) => {
   const team = await prisma.team.findUnique({
@@ -352,8 +353,10 @@ export const deleteFile = async (fileId: number, userId: number) => {
   if (!isMember)
     throw new AppError("Not a team member.", 403);
 
-  const filePath = `/app${file.file_url}`;
+  const filename = path.basename(file.file_url);
 
+  const filePath = path.join('/app/uploads/tasks', filename);
+  
   fs.unlink(filePath, (err) => {
     if (err) console.error("File delete error:", err);
   });


### PR DESCRIPTION
While reviewing a PR, I noticed that deleting a file from a task was only deleting it from the database, not from local volume as we do for avatar uploads. For consistency and to occupy less space in storage, I fixed that.