### PR TITLE
72 implement friend status

### DIFF
--- a/project/backend/application/src/users/users.controller.ts
+++ b/project/backend/application/src/users/users.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { getMe, updateMe, searchUsers, getUserById } from './users.service.js';
+import { getMe, updateMe, searchUsers, getUserById, getUserState } from './users.service.js';
 import type { AuthRequest } from '../middleware/auth.middleware.js';
 import type { UpdateUserDTO } from './users.types.js';
 
@@ -33,6 +33,14 @@ export const getUserByIdController = async (req: Request, res: Response) => {
   const id = Number(req.params.id);
 
   const user = await getUserById(id);
+
+  return res.json(user);
+};
+
+export const getUserStateController = async (req: Request, res: Response) => {
+  const id = Number(req.params.id);
+
+  const user = await getUserState(id);
 
   return res.json(user);
 };

--- a/project/backend/application/src/users/users.routes.ts
+++ b/project/backend/application/src/users/users.routes.ts
@@ -1,6 +1,6 @@
 import { Router } from 'express';
 import { authMiddleware } from '../middleware/auth.middleware.js';
-import { getMeController, updateMeController, searchUsersController, getUserByIdController } from './users.controller.js';
+import { getMeController, updateMeController, searchUsersController, getUserByIdController, getUserStateController } from './users.controller.js';
 import { asyncHandler } from '../utils/AppError.js';
 import { uploadAvatar } from '../middleware/uploadAvatar.js';
 
@@ -10,5 +10,6 @@ router.get('/me', authMiddleware, asyncHandler(getMeController));
 router.put('/me', authMiddleware, uploadAvatar.single('avatar'), asyncHandler(updateMeController));
 router.get('/search', authMiddleware, asyncHandler(searchUsersController));
 router.get('/:id', authMiddleware, asyncHandler(getUserByIdController));
+router.get('/:id/online', authMiddleware, asyncHandler(getUserStateController));
 
 export default router;

--- a/project/backend/application/src/users/users.service.ts
+++ b/project/backend/application/src/users/users.service.ts
@@ -3,6 +3,7 @@ import { AppError } from '../utils/AppError.js';
 import type { UpdateUserDTO } from './users.types.js';
 import fs from 'fs';
 import path from 'path';
+import { getOnlineUsers } from '../utils/socket.js';
 
 export const getMe = async (userId: number) => {
   const user = await prisma.user.findUnique({
@@ -168,4 +169,13 @@ export const searchUsers = async (query: string) => {
     ...user,
     avatar_url: user.avatar_url || "/api/public/avatars/default.png",
   }));
+};
+
+export const getUserState = async (userId: number) => {
+	const user = getOnlineUsers().get(userId);
+
+	if (user)
+		return { Online: true };
+	else
+		return { Online: false };
 };

--- a/project/backend/application/src/utils/socket.ts
+++ b/project/backend/application/src/utils/socket.ts
@@ -2,8 +2,11 @@ import { Server } from 'socket.io';
 import type { Server as HTTPServer } from 'http';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../config.js';
+import { getFriends } from '../friends/friends.service.js';
 
 let io: Server;
+
+var onlineUsers = new Map<number, Set<string>>();
 
 interface EventResponse {
 	status: String
@@ -44,6 +47,22 @@ export const initSocket = (httpServer: HTTPServer) => {
 
 		console.log(`User ${userId} connected with socket ${socket.id}`);
 
+		if (!onlineUsers.has(userId))
+			onlineUsers.set(userId, new Set());
+
+		onlineUsers.get(userId)!.add(socket.id);
+
+		getFriends(userId).then(friends => {
+			const friendsIds = friends.map(f => f.id);
+
+			if (onlineUsers.get(userId)!.size === 1) 
+					friendsIds.forEach(fid => io.to(`user:${fid}`).emit('user online', userId));
+
+			const onlineFriendsIds = friendsIds.filter(fid => onlineUsers.has(fid));
+			socket.emit('online friends', onlineFriendsIds);
+				
+		}).catch(err => console.error('Failed on connect:', err));
+
 		socket.on('join chat', async (userId: number, friendId: number, callback: ({ status }: EventResponse) => void) => {
 			var chatId = "";
 
@@ -80,9 +99,22 @@ export const initSocket = (httpServer: HTTPServer) => {
 			callback({ status: 'team chat leave acknownledged' });
 		});
 
-		socket.on('disconnect', () => {
+		socket.on('disconnect', async () => {
 			console.log(`User ${userId} disconnected`);
+
+			const sockets = onlineUsers.get(userId);
+			if (sockets) {
+				sockets.delete(socket.id);
+				if (sockets.size === 0) {
+					onlineUsers.delete(userId);
+
+					getFriends(userId).then(friends => {
+						friends.map(f => f.id).forEach(fid => io.to(`user:${fid}`).emit('user offline', userId));
+					}).catch(err => console.error('Failed on disconnect:', err));
+				}
+			}
 		});
+
 	});
 
 	return io;
@@ -93,4 +125,11 @@ export const getIO = () => {
 		throw new Error('Socket.IO not initialized.');
 
 	return io;
+};
+
+export const getOnlineUsers = () => {
+	if (!onlineUsers)
+		throw new Error('onlineUsers is not initialized.');
+
+	return onlineUsers;
 };

--- a/test/online_status_test/client.mjs
+++ b/test/online_status_test/client.mjs
@@ -1,0 +1,367 @@
+import { io } from 'socket.io-client';
+
+const API = 'https://localhost/api';
+
+async function api(method, path, token, body) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+  const data = await res.json();
+  if (!res.ok) {
+    console.error(`FAIL: ${method} ${path} — ${res.status} ${JSON.stringify(data)}`);
+    process.exit(1);
+  }
+  return data;
+}
+
+async function login(email) {
+  const data = await api('POST', '/auth/login', null, { email, password: 'pass12345' });
+  console.log(`  Logged in ${data.user.username} (id: ${data.user.id})`);
+  return data;
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`FAIL: ${msg}`);
+    process.exit(1);
+  }
+}
+
+function waitForEvent(socket, event, filterFn, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Timeout waiting for '${event}'`)), timeoutMs);
+    socket.on(event, (...args) => {
+      if (filterFn(...args)) {
+        clearTimeout(timer);
+        resolve(args);
+      }
+    });
+  });
+}
+
+async function main() {
+  console.log('=== Online Status Test ===\n');
+
+  const { token: tokenA, user: userA } = await login('testuser@student.42i');
+  const { token: tokenB, user: userB } = await login('felix@example.com');
+  const { token: tokenC, user: userC } = await login('max@example.com');
+
+  // ============================================================
+  // PHASE 1: Basic online / offline
+  // ============================================================
+  console.log('\n-- Phase 1: Basic online/offline --');
+
+  const socketB = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenB },
+  });
+
+  socketB.on('connect_error', err => {
+    console.error('FAIL: Socket B connect error —', err.message);
+    process.exit(1);
+  });
+
+  // Wait for socketB to connect
+  await new Promise(r => socketB.on('connect', r));
+  console.log('  Socket B (Felix) connected');
+
+  // Listen for userA online/offline on socketB
+  const bOnline = waitForEvent(socketB, 'user online', (id) => id === userA.id, 8000);
+  const bOffline = waitForEvent(socketB, 'user offline', (id) => id === userA.id, 8000);
+
+  // Connect socketA — should trigger 'user online' on socketB
+  const socketA = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+
+  socketA.on('connect_error', err => {
+    console.error('FAIL: Socket A connect error —', err.message);
+    process.exit(1);
+  });
+
+  await new Promise(r => socketA.on('connect', r));
+  console.log('  Socket A (TestUser) connected');
+
+  // Verify socketB received 'user online' for userA
+  const [onlineUserId] = await bOnline;
+  assert(onlineUserId === userA.id, `Expected user online ${userA.id}, got ${onlineUserId}`);
+  console.log(`  Socket B received 'user online' for user ${onlineUserId}`);
+
+  // REST check: should be online
+  const state1 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state1.Online === true, `Expected Online=true, got ${state1.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state1.Online} }`);
+
+  // Disconnect socketA — should trigger 'user offline' on socketB
+  socketA.disconnect();
+  console.log('  Socket A disconnected');
+
+  const [offlineUserId] = await bOffline;
+  assert(offlineUserId === userA.id, `Expected user offline ${userA.id}, got ${offlineUserId}`);
+  console.log(`  Socket B received 'user offline' for user ${offlineUserId}`);
+
+  // REST check: should be offline
+  const state2 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state2.Online === false, `Expected Online=false, got ${state2.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state2.Online} }`);
+
+  console.log('PASS: Phase 1');
+
+  // ============================================================
+  // PHASE 2: Multi-tab (same user, two socket connections)
+  // ============================================================
+  console.log('\n-- Phase 2: Multi-tab --');
+
+  // Reconnect socketA (first "tab")
+  const socketA1 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+  socketA1.on('connect_error', err => {
+    console.error('FAIL: Socket A1 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketA1.on('connect', r));
+  console.log('  Socket A1 (TestUser, tab 1) connected');
+
+  // Wait briefly for online event to propagate
+  await new Promise(r => setTimeout(r, 500));
+
+  // REST check: should be online again
+  const state3 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state3.Online === true, `Expected Online=true, got ${state3.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state3.Online} }`);
+
+  // Connect a second socket for same user (tab 2)
+  const socketA2 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+  socketA2.on('connect_error', err => {
+    console.error('FAIL: Socket A2 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketA2.on('connect', r));
+  console.log('  Socket A2 (TestUser, tab 2) connected');
+
+  // Wait — the server should NOT emit 'user online' again (already online)
+  await new Promise(r => setTimeout(r, 1000));
+
+  // REST still online
+  const state4 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state4.Online === true, `Expected Online=true, got ${state4.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state4.Online} } (still online after second tab)`);
+
+  // Listen for offline on socketB — should NOT fire when only one tab disconnects
+  let offlineFired = false;
+  const offlineListener = (id) => {
+    if (id === userA.id) offlineFired = true;
+  };
+  socketB.on('user offline', offlineListener);
+
+  // Disconnect tab 1 only
+  socketA1.disconnect();
+  console.log('  Socket A1 (tab 1) disconnected');
+
+  // Wait — should NOT get 'user offline' (tab 2 still connected)
+  await new Promise(r => setTimeout(r, 1500));
+
+  assert(offlineFired === false, 'Should NOT emit user offline when one of two tabs remains');
+  console.log('  No spurious offline event (tab 2 still connected)');
+
+  // REST still online
+  const state5 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state5.Online === true, `Expected Online=true, got ${state5.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state5.Online} }`);
+
+  socketB.removeListener('user offline', offlineListener);
+
+  // Disconnect tab 2 — now should get offline
+  const bOffline2 = waitForEvent(socketB, 'user offline', (id) => id === userA.id, 8000);
+  socketA2.disconnect();
+  console.log('  Socket A2 (tab 2) disconnected');
+
+  const [offline2] = await bOffline2;
+  assert(offline2 === userA.id, `Expected user offline ${userA.id}, got ${offline2}`);
+  console.log(`  Socket B received 'user offline' for user ${offline2}`);
+
+  // REST check: offline again
+  const state6 = await api('GET', `/users/${userA.id}/online`, tokenA);
+  assert(state6.Online === false, `Expected Online=false, got ${state6.Online}`);
+  console.log(`  GET /users/${userA.id}/online → { Online: ${state6.Online} }`);
+
+  console.log('PASS: Phase 2');
+
+  // ============================================================
+  // PHASE 3: Non-friend should NOT receive online/offline events
+  // ============================================================
+  console.log('\n-- Phase 3: Friend-only scope --');
+
+  // Connect non-friend C (Max, not friends with TestUser)
+  const socketC = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenC },
+  });
+  socketC.on('connect_error', err => {
+    console.error('FAIL: Socket C connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketC.on('connect', r));
+  console.log('  Socket C (Max, non-friend) connected');
+
+  // Reconnect B (Felix, friend)
+  const socketB3 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenB },
+  });
+  socketB3.on('connect_error', err => {
+    console.error('FAIL: Socket B3 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketB3.on('connect', r));
+  console.log('  Socket B (Felix, friend) reconnected');
+
+  // B waits for A's online event; C flags it
+  const bOnline3 = waitForEvent(socketB3, 'user online', (id) => id === userA.id, 8000);
+  let cOnlineFired = false;
+  socketC.on('user online', (id) => { if (id === userA.id) cOnlineFired = true; });
+
+  // Connect A (TestUser) — triggers 'user online'
+  const socketA3 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+  socketA3.on('connect_error', err => {
+    console.error('FAIL: Socket A3 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketA3.on('connect', r));
+  console.log('  Socket A (TestUser) connected');
+
+  const [online3] = await bOnline3;
+  assert(online3 === userA.id, `B expected online ${userA.id}, got ${online3}`);
+  console.log(`  B received 'user online' for user ${online3}`);
+
+  // Give C's event a moment to fire (should not)
+  await new Promise(r => setTimeout(r, 1000));
+  assert(cOnlineFired === false, 'C (non-friend) should NOT receive user online');
+  console.log('  C (non-friend) correctly did NOT receive user online');
+
+  // Setup offline listeners
+  const bOffline3 = waitForEvent(socketB3, 'user offline', (id) => id === userA.id, 8000);
+  let cOfflineFired = false;
+  socketC.on('user offline', (id) => { if (id === userA.id) cOfflineFired = true; });
+
+  // Disconnect A — triggers 'user offline'
+  socketA3.disconnect();
+  console.log('  Socket A disconnected');
+
+  const [offline3] = await bOffline3;
+  assert(offline3 === userA.id, `B expected offline ${userA.id}, got ${offline3}`);
+  console.log(`  B received 'user offline' for user ${offline3}`);
+
+  await new Promise(r => setTimeout(r, 1000));
+  assert(cOfflineFired === false, 'C (non-friend) should NOT receive user offline');
+  console.log('  C (non-friend) correctly did NOT receive user offline');
+
+  socketB3.disconnect();
+  socketC.disconnect();
+
+  console.log('PASS: Phase 3');
+
+  // Close Phase 1 socket so Felix has no stale connection in Phase 4
+  socketB.disconnect();
+
+  // ============================================================
+  // PHASE 4: Online friends snapshot on connect
+  // ============================================================
+  console.log('\n-- Phase 4: Online friends snapshot --');
+
+  // Connect C (Max, non-friend of A) — online but should not appear
+  const socketC4 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenC },
+  });
+  socketC4.on('connect_error', err => {
+    console.error('FAIL: Socket C4 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketC4.on('connect', r));
+  console.log('  Socket C (Max, non-friend) connected');
+
+  // Connect B (Felix, friend of A) — online, expect in snapshot
+  const socketB4 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenB },
+  });
+  socketB4.on('connect_error', err => {
+    console.error('FAIL: Socket B4 connect error —', err.message);
+    process.exit(1);
+  });
+  await new Promise(r => socketB4.on('connect', r));
+  console.log('  Socket B (Felix, friend) connected');
+
+  // Connect A → snapshot includes friend B, excludes non-friend C
+  const socketA4 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+  socketA4.on('connect_error', err => {
+    console.error('FAIL: Socket A4 connect error —', err.message);
+    process.exit(1);
+  });
+  const aSnapshot4 = waitForEvent(socketA4, 'online friends', () => true, 8000);
+  await new Promise(r => socketA4.on('connect', r));
+  console.log('  Socket A (TestUser) connected');
+
+  const [friendIds4] = await aSnapshot4;
+  assert(Array.isArray(friendIds4), 'Expected online friends to be an array');
+  assert(friendIds4.includes(userB.id), `Snapshot should include friend B (${userB.id})`);
+  assert(!friendIds4.includes(userC.id), `Snapshot should NOT include non-friend C (${userC.id})`);
+  console.log(`  Snapshot includes friend B=${friendIds4.includes(userB.id)}, excludes non-friend C=${!friendIds4.includes(userC.id)}`);
+
+  // Disconnect B → goes offline
+  socketB4.disconnect();
+  console.log('  Socket B disconnected');
+
+  // Let offline propagate
+  await new Promise(r => setTimeout(r, 500));
+
+  // Reconnect A → snapshot should no longer include B
+  const socketA5 = io('https://localhost', {
+    transports: ['websocket'], rejectUnauthorized: false,
+    auth: { token: tokenA },
+  });
+  socketA5.on('connect_error', err => {
+    console.error('FAIL: Socket A5 connect error —', err.message);
+    process.exit(1);
+  });
+  const aSnapshot5 = waitForEvent(socketA5, 'online friends', () => true, 8000);
+  await new Promise(r => socketA5.on('connect', r));
+  console.log('  Socket A (TestUser) reconnected');
+
+  const [friendIds5] = await aSnapshot5;
+  assert(Array.isArray(friendIds5), 'Expected online friends to be an array');
+  assert(!friendIds5.includes(userB.id), `Snapshot should NOT include offline friend B (${userB.id})`);
+  console.log(`  Snapshot correctly excludes offline friend B`);
+
+  socketA4.disconnect();
+  socketA5.disconnect();
+  socketC4.disconnect();
+
+  console.log('PASS: Phase 4');
+
+  console.log('\nPASS: All phases');
+  process.exit(0);
+}
+
+main().catch(err => {
+  console.error(`FAIL: ${err.message}`);
+  process.exit(1);
+});

--- a/test/online_status_test/package-lock.json
+++ b/test/online_status_test/package-lock.json
@@ -1,0 +1,120 @@
+{
+  "name": "online_status_test",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "socket.io-client": "^4.7.2"
+      }
+    },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/engine.io-client": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    }
+  }
+}

--- a/test/online_status_test/package.json
+++ b/test/online_status_test/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "socket.io-client": "^4.7.2"
+  }
+}


### PR DESCRIPTION
# Online Status Feature

## Events

| Event | Direction | Payload | When |
|---|---|---|---|
| `'online friends'` | server → client | `number[]` | On socket connect — snapshot of friend IDs currently online |
| `'user online'` | server → friends only | `userId: number` | User's first socket connects |
| `'user offline'` | server → friends only | `userId: number` | User's last socket disconnects |

## REST endpoint

```
GET /api/users/:id/online  →  { Online: true }  or  { Online: false }
```

## Key logic

- `project/backend/application/src/utils/socket.ts` — `io.use` middleware authenticates via `socket.handshake.auth.token`. On connect, registers the socket, calls `getFriends(userId)`, emits `'online friends'` snapshot to the connecting user, and emits `'user online'` to friends only on the first socket for that user. On disconnect, emits `'user offline'` to friends only when the last socket is removed.
- `map<userId, Set<socketId>>` tracks all sockets per user. `'user online'` fires only when `size === 1`; `'user offline'` fires only when `size === 0`.
- Emits are scoped to `user:{friendId}` rooms — non-friends never receive status events.

## How to test

```bash
cd test/online_status_test
NODE_TLS_REJECT_UNAUTHORIZED=0 node client.mjs
```

The test covers:
- **Phase 1** — Basic online/offline delivery between friends + REST endpoint
- **Phase 2** — Multi-tab (same user, two sockets): no false offline when one tab closes
- **Phase 3** — Friend-only scope: non-friend does NOT receive `'user online'` / `'user offline'`
- **Phase 4** — `'online friends'` snapshot on connect: includes online friends, excludes non-friends and offline friends

*P.S.: AI was used for the tests*