### PR TITLE
52 frontend  errors verification

### DIFF
--- a/project/backend/application/src/auth/auth.controller.ts
+++ b/project/backend/application/src/auth/auth.controller.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { register, login } from './auth.service.js';
+import { register, login, checkEmail } from './auth.service.js';
 
 export const registerUser = async (req: Request, res: Response) => {
   const result = await register(req.body);
@@ -8,5 +8,11 @@ export const registerUser = async (req: Request, res: Response) => {
 
 export const loginUser = async (req: Request, res: Response) => {
   const result = await login(req.body);
+  res.json(result);
+};
+
+export const checkEmailController = async (req: Request, res: Response) => {
+  const { email } = req.body;
+  const result = await checkEmail(email);
   res.json(result);
 };

--- a/project/backend/application/src/auth/auth.routes.ts
+++ b/project/backend/application/src/auth/auth.routes.ts
@@ -1,10 +1,11 @@
 import express from 'express';
-import { registerUser, loginUser } from './auth.controller.js';
+import { registerUser, loginUser, checkEmailController } from './auth.controller.js';
 import { asyncHandler } from '../utils/AppError.js';
 
 const router = express.Router();
 
 router.post('/register', asyncHandler(registerUser));
 router.post('/login', asyncHandler(loginUser));
+router.post('/check-email', asyncHandler(checkEmailController));
 
 export default router;

--- a/project/backend/application/src/auth/auth.service.ts
+++ b/project/backend/application/src/auth/auth.service.ts
@@ -46,6 +46,18 @@ export const register = async (data: RegisterDTO) => {
   };
 };
 
+export const checkEmail = async (email: string) => {
+  if (!email) {
+    throw new AppError('Email is required', 400);
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { email },
+  });
+
+  return { exists: !!user };
+};
+
 export const login = async (data: LoginDTO) => {
   const { email, password } = data;
 

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -60,6 +60,7 @@ export const readNotification = async (userId: number, notificationId: number) =
 		where: {
 			id: notificationId,
 			user_id_receiver: userId,
+			status_read: false,
 		},
 	});
 

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -33,7 +33,7 @@ export const getUnreadNotifications = async (userId: number) => {
 	const notifications = await prisma.notification.findMany({
 		where: {
 			user_id_receiver: userId,
-			status_read: false,
+			status_read: false, // <- Problemo
 		},
 		orderBy: {
 			created_at: 'desc',

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -33,7 +33,7 @@ export const getUnreadNotifications = async (userId: number) => {
 	const notifications = await prisma.notification.findMany({
 		where: {
 			user_id_receiver: userId,
-			status_read: false, // <- Problemo
+			status_read: false,
 		},
 		orderBy: {
 			created_at: 'desc',

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -51,7 +51,7 @@ export const getUnreadNotifications = async (userId: number) => {
 	});
 
 	return notifications;
-};
+}; 
 
 // Reads a specific notification with id
 export const readNotification = async (userId: number, notificationId: number) => {
@@ -60,7 +60,6 @@ export const readNotification = async (userId: number, notificationId: number) =
 		where: {
 			id: notificationId,
 			user_id_receiver: userId,
-			status_read: false,
 		},
 	});
 

--- a/project/backend/application/src/teams/teams.controller.ts
+++ b/project/backend/application/src/teams/teams.controller.ts
@@ -1,7 +1,7 @@
 import type { Response } from 'express';
 import type { AuthRequest } from '../middleware/auth.middleware.js';
 import { AppError } from '../utils/AppError.js';
-import { getTeamsList, createTeam, getTeam, updateTeam, deleteTeam, getTeamMembers, removeTeamMember, getTeamJoinRequests, sendTeamJoinRequest, acceptJoinRequest, rejectJoinRequest, getTeamInvites, sendTeamInvite, acceptTeamInvite, rejectTeamInvite, leaveTeam } from './teams.services.js';
+import { getTeamsList, createTeam, getTeam, updateTeam, deleteTeam, getTeamMembers, removeTeamMember, getTeamJoinRequests, sendTeamJoinRequest, acceptJoinRequest, rejectJoinRequest, getTeamInvites, getTeamInvitesSent, sendTeamInvite, acceptTeamInvite, rejectTeamInvite, leaveTeam } from './teams.services.js';
 
 export const getTeamsListController = async (req: AuthRequest, res: Response) => {
 	const teamList = await getTeamsList();
@@ -133,6 +133,13 @@ export const rejectJoinRequestController = async (req: AuthRequest, res: Respons
 export const getTeamInvitesController = async (req: AuthRequest, res: Response) => {
 	const invites = await getTeamInvites(req.user!.id);
 	return res.json(invites);
+};
+
+export const getTeamInvitesSentController = async (req: AuthRequest, res: Response) => {
+	const teamId = Number(req.params.id);
+
+	const invites_sent = await getTeamInvitesSent(teamId);
+	return res.json(invites_sent);
 };
 
 export const sendTeamInviteController = async (req: AuthRequest, res: Response) => {

--- a/project/backend/application/src/teams/teams.routes.ts
+++ b/project/backend/application/src/teams/teams.routes.ts
@@ -1,7 +1,7 @@
 import { Router } from "express";
 import { asyncHandler } from "../utils/AppError.js";
 import { authMiddleware } from "../middleware/auth.middleware.js";
-import { getTeamsListController, createTeamController, getTeamController, updateTeamController, deleteTeamController, getTeamMembersController, removeTeamMemberController, getTeamJoinRequestsController, sendTeamJoinRequestController, acceptJoinRequestController, rejectJoinRequestController, getTeamInvitesController, sendTeamInviteController, acceptTeamInviteController, rejectTeamInviteController, leaveTeamController } from "./teams.controller.js";
+import { getTeamsListController, createTeamController, getTeamController, updateTeamController, deleteTeamController, getTeamMembersController, removeTeamMemberController, getTeamJoinRequestsController, sendTeamJoinRequestController, acceptJoinRequestController, rejectJoinRequestController, getTeamInvitesController, getTeamInvitesSentController, sendTeamInviteController, acceptTeamInviteController, rejectTeamInviteController, leaveTeamController } from "./teams.controller.js";
 import { createTaskController, getTeamTasksController } from "../tasks/tasks.controller.js";
 import { getTeamSentMessagesController, getTeamReceivedMessagesController, getAllMessagesController, sendTeamMessageController, deleteTeamMessageController, } from "./team_message.controller.js";
 
@@ -22,6 +22,7 @@ router.post('/:id/join-requests/:requestId/reject', authMiddleware, asyncHandler
 router.get('/:id/join-requests', authMiddleware, asyncHandler(getTeamJoinRequestsController));
 router.post('/:id/join-requests', authMiddleware, asyncHandler(sendTeamJoinRequestController));
 
+router.get('/:id/invites-sent', authMiddleware, asyncHandler(getTeamInvitesSentController));
 router.post('/:id/invites', authMiddleware, asyncHandler(sendTeamInviteController));
 router.delete('/:id/leave', authMiddleware, asyncHandler(leaveTeamController));
 

--- a/project/backend/application/src/teams/teams.services.ts
+++ b/project/backend/application/src/teams/teams.services.ts
@@ -573,6 +573,31 @@ export const getTeamInvites = async (userId: number) => {
 	return invite_list;
 };
 
+// Get list of team invites sent
+export const getTeamInvitesSent = async (teamId: number) => {
+
+	const invitesSent = await prisma.teamInvite.findMany({
+		where: {
+			team_id: teamId,
+			status: 'pending',
+		},
+		select: {
+			id: true,
+			created_at: true,
+			user_id: true,
+		}
+	});
+
+	const invite_sent_list = invitesSent.map((invite) => ({
+		invite_id: invite.id,
+		sent_at: invite.created_at,
+		user_id: invite.user_id,
+	}));
+
+	return invite_sent_list;
+};
+
+
 // Send invite from team to user
 export const sendTeamInvite = async (userId: number, teamId: number, receiverId: number) => {
 

--- a/project/frontend/application/src/App.tsx
+++ b/project/frontend/application/src/App.tsx
@@ -8,6 +8,7 @@
 import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { useContext, useEffect, ReactNode } from 'react';
 import { AuthProvider, AuthContext } from './context/AuthContext';
+import { ErrorProvider } from './context/ErrorContext';
 import Feed from './pages/feed/Feed';
 import Login from './pages/auth/Login';
 import Register from './pages/auth/Register';
@@ -48,6 +49,7 @@ function ProtectedRoute({ children }: ProtectedRouteProps) {
 function App() {
   return (
     <AuthProvider> {/* Provides authentication context to the entire app. */}
+      <ErrorProvider>
       <Router> {/* Enables navigation, /login, /profile, etc. */}
         <Routes> {/* Container for all routes. */}
           <Route
@@ -154,6 +156,7 @@ function App() {
           />
         </Routes>
       </Router>
+      </ErrorProvider>
     </AuthProvider>
   );
 }

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -461,6 +461,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   };
 
   const markAsRead = (id: number) => {
+    const notif = notifications.find(n => n.id === id);
+    if (notif?.status_read) return;
+
     api.readNotification(id).then(() => {
       setNotifications((prev) =>
         prev.map((n) => (n.id === id ? { ...n, status_read: true } : n))

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -70,7 +70,10 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   }, []);
 
   useEffect(() => {
-    const handleFocus = () => fetchNotifications();
+    const handleFocus = () => {
+      const token = localStorage.getItem('authToken');
+      if (token) fetchNotifications();
+    };
     window.addEventListener('focus', handleFocus);
     return () => window.removeEventListener('focus', handleFocus);
   }, []);
@@ -141,7 +144,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       setUser({ ...user, teams: updatedTeams });
       fetchNotifications();
     } catch (err) {
-      console.error('Failed to leave team:', err);
       throw err;
     }
   };
@@ -190,8 +192,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         return team;
       });
       setUser({ ...user, teams: updatedTeams });
-    } catch (err) {
-      console.error('Failed to update task status:', err);
+    } catch {
     }
   };
 
@@ -210,8 +211,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         return team;
       });
       setUser({ ...user, teams: updatedTeams });
-    } catch (err) {
-      console.error('Failed to add task:', err);
+    } catch {
     }
   };
 
@@ -239,7 +239,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       });
       setUser({ ...user, teams: updatedTeams });
     } catch (err) {
-      console.error('Failed to upload file:', err);
       throw err;
     }
   };
@@ -264,7 +263,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       });
       setUser({ ...user, teams: updatedTeams });
     } catch (err) {
-      console.error('Failed to delete file:', err);
       throw err;
     }
   };
@@ -287,8 +285,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         return team;
       });
       setUser({ ...user, teams: updatedTeams });
-    } catch (err) {
-      console.error('Failed to update task assignee:', err);
+    } catch {
     }
   };
 
@@ -340,7 +337,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       });
       setUser({ ...user, teams: updatedTeams });
     } catch (err) {
-      console.error('Failed to remove team member:', err);
       throw err;
     }
   };
@@ -374,7 +370,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         teams: [...user.teams, team],
       });
     } catch (err) {
-      console.error('Failed to create team:', err);
       throw err;
     }
   };
@@ -389,7 +384,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       });
       setUser({ ...user, teams: updatedTeams });
     } catch (err) {
-      console.error('Failed to update team status:', err);
       throw err;
     }
   };
@@ -414,9 +408,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const fetchFriendRequests = () => {
     api.getFriendRequests().then((requests) => {
       setFriendRequests(requests);
-    }).catch((err) => {
-      console.error('Failed to fetch friend requests:', err);
-    });
+    }).catch(() => {});
   };
 
   const acceptFriendRequest = (requestId: number) => {
@@ -425,9 +417,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       fetchFriendRequests();
       fetchFriends();
       fetchNotifications();
-    }).catch((err) => {
-      console.error('Failed to accept friend request:', err);
-    });
+    }).catch(() => {});
   };
 
   const rejectFriendRequest = (requestId: number) => {
@@ -436,17 +426,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       fetchFriendRequests();
       fetchSentRequests();
       fetchNotifications();
-    }).catch((err) => {
-      console.error('Failed to reject friend request:', err);
-    });
+    }).catch(() => {});
   };
 
   const fetchSentRequests = () => {
     api.getSentFriendRequests().then((requests) => {
       setSentRequests(requests);
-    }).catch((err) => {
-      console.error('Failed to fetch sent requests:', err);
-    });
+    }).catch(() => {});
   };
 
   const fetchFriends = () => {
@@ -455,9 +441,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       if (user) {
         setUser({ ...user, friends: friendList });
       }
-    }).catch((err) => {
-      console.error('Failed to fetch friends:', err);
-    });
+    }).catch(() => {});
   };
 
   const removeFriend = (friendId: number) => {
@@ -466,18 +450,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       if (user) {
         setUser({ ...user, friends: user.friends.filter((f) => f.id !== friendId) });
       }
-    }).catch((err) => {
-      console.error('Failed to remove friend:', err);
-    });
+    }).catch(() => {});
   };
 
   const fetchNotifications = () => {
     api.getNotifications().then((list) => {
       setNotifications(list);
       setUnreadCount(list.filter((n) => !n.status_read).length);
-    }).catch((err) => {
-      console.error('Failed to fetch notifications:', err);
-    });
+    }).catch(() => {});
   };
 
   const markAsRead = (id: number) => {
@@ -497,9 +477,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     api.readAllNotifications().then(() => {
       setNotifications((prev) => prev.map((n) => ({ ...n, status_read: true })));
       setUnreadCount(0);
-    }).catch((err) => {
-      console.error('Failed to mark all as read:', err);
-    });
+    }).catch(() => {});
   };
 
   const deleteNotification = (id: number) => {
@@ -511,27 +489,21 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         }
         return prev.filter((n) => n.id !== id);
       });
-    }).catch((err) => {
-      console.error('Failed to delete notification:', err);
-    });
+    }).catch(() => {});
   };
 
   const deleteAllNotifications = () => {
     api.deleteAllNotifications().then(() => {
       setNotifications([]);
       setUnreadCount(0);
-    }).catch((err) => {
-      console.error('Failed to delete all notifications:', err);
-    });
+    }).catch(() => {});
   };
 
   const fetchTeamInvites = () => {
     api.getTeamInvites().then((invites) => {
       setTeamInvites(invites);
       setUnreadNotifications(invites.length + joinRequestNotifications.length);
-    }).catch((err) => {
-      console.error('Failed to fetch team invites:', err);
-    });
+    }).catch(() => {});
   };
 
   const fetchJoinRequestNotifications = async (userId?: number) => {
@@ -562,8 +534,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       );
       setJoinRequestNotifications(allRequests);
       setUnreadNotifications(teamInvites.length + allRequests.length);
-    } catch (err) {
-      console.error('Failed to fetch join request notifications:', err);
+    } catch {
     }
   };
 
@@ -573,9 +544,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       setUnreadNotifications((prev) => Math.max(0, prev - 1));
       fetchNotifications();
       setTimeout(() => window.location.reload(), 300);
-    }).catch((err) => {
-      console.error('Failed to accept team invite:', err);
-    });
+    }).catch(() => {});
   };
 
   const rejectTeamInvite = (inviteId: number) => {
@@ -583,9 +552,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       setTeamInvites(teamInvites.filter((i) => i.invite_id !== inviteId));
       setUnreadNotifications((prev) => Math.max(0, prev - 1));
       fetchNotifications();
-    }).catch((err) => {
-      console.error('Failed to reject team invite:', err);
-    });
+    }).catch(() => {});
   };
 
   const markNotificationsRead = () => {

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -94,7 +94,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
               fetchFriendRequests();
               fetchSentRequests();
             }
-            if (n.type === 'friend_request_accepted') {
+            if (n.type === 'friend_request_accepted' || n.type === 'friend_removed') {
               fetchFriends();
             }
             if (n.type === 'team_invite' || n.type === 'team_invite_accepted'

--- a/project/frontend/application/src/context/ErrorContext.tsx
+++ b/project/frontend/application/src/context/ErrorContext.tsx
@@ -1,0 +1,59 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+interface ErrorInfo {
+  title: string;
+  message: string;
+}
+
+interface ErrorContextType {
+  showError: (title: string, message: string) => void;
+}
+
+const ErrorContext = createContext<ErrorContextType>({
+  showError: () => {},
+});
+
+export function useError() {
+  return useContext(ErrorContext);
+}
+
+interface ErrorProviderProps {
+  children: ReactNode;
+}
+
+export function ErrorProvider({ children }: ErrorProviderProps) {
+  const [error, setError] = useState<ErrorInfo | null>(null);
+
+  const showError = (title: string, message: string) => {
+    setError({ title, message });
+  };
+
+  return (
+    <ErrorContext.Provider value={{ showError }}>
+      {error && (
+        <div className="modal-overlay" onClick={() => setError(null)}>
+          <div className="modal" onClick={(e) => e.stopPropagation()}>
+            <div className="modal-header">
+              <h2>{error.title}</h2>
+              <button className="modal-close" onClick={() => setError(null)}>&times;</button>
+            </div>
+            <div className="modal-body">
+              <div className="error-content">
+                <div className="error-icon">
+                  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor">
+                    <path fillRule="evenodd" d="M12 2.25c-5.385 0-9.75 4.365-9.75 9.75s4.365 9.75 9.75 9.75 9.75-4.365 9.75-9.75S17.385 2.25 12 2.25zm-1.72 6.97a.75.75 0 10-1.06 1.06L10.94 12l-1.72 1.72a.75.75 0 101.06 1.06L12 13.06l1.72 1.72a.75.75 0 101.06-1.06L13.06 12l1.72-1.72a.75.75 0 10-1.06-1.06L12 10.94l-1.72-1.72z" clipRule="evenodd" />
+                  </svg>
+                </div>
+                <p className="error-message">{error.message}</p>
+              </div>
+              <div className="modal-actions" style={{ marginTop: '1rem', display: 'flex', justifyContent: 'center', gap: '0.5rem' }}>
+                <button className="btn btn-primary" onClick={() => setError(null)}>OK</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+      {children}
+    </ErrorContext.Provider>
+  );
+}

--- a/project/frontend/application/src/context/ErrorContext.tsx
+++ b/project/frontend/application/src/context/ErrorContext.tsx
@@ -31,7 +31,7 @@ export function ErrorProvider({ children }: ErrorProviderProps) {
   return (
     <ErrorContext.Provider value={{ showError }}>
       {error && (
-        <div className="modal-overlay" onClick={() => setError(null)}>
+        <div className="modal-overlay" style={{ zIndex: 1100 }} onClick={() => setError(null)}>
           <div className="modal" onClick={(e) => e.stopPropagation()}>
             <div className="modal-header">
               <h2>{error.title}</h2>

--- a/project/frontend/application/src/css-styles/index.css
+++ b/project/frontend/application/src/css-styles/index.css
@@ -11,7 +11,6 @@
 @import '06-profile.css';
 @import '06a-profile-pages.css';
 @import '07-teams.css';
-@import '07b-teams-tasks.css';
 @import '08-chat.css';
 @import '09-modals.css';
 @import '10-security.css';

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -270,7 +270,11 @@
     "chat": "Chat",
     "noReceivedRequests": "No pending requests",
     "noSentRequests": "No pending sent requests",
-    "friendRequestExists": "A pending friend request already exists."
+    "friendRequestExists": "A pending friend request already exists.",
+    "alreadyFriends": "You are already friends.",
+    "addFriendFailed": "Failed to send friend request.",
+    "userNotFound": "User not found.",
+    "loadUsersFailed": "Failed to load users."
   },
   "chat": {
     "title": "Chat",

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -338,7 +338,8 @@
     "teamInviteRejected": "{{username}} declined your invite to join {{team}}.",
     "teamRemoved": "You were removed from the {{team}} team.",
     "teamUserLeft": "{{username}} left {{team}}.",
-    "teamDeleted": "The {{team}} team has been deleted by its owner."
+    "teamDeleted": "The {{team}} team has been deleted by its owner.",
+    "teamLoadFailed": "Failed to load team information."
   },
   "legal": {
     "privacy": {

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -212,10 +212,17 @@
     "saveSettings": "Save Settings",
     "settingsUpdated": "Team settings updated",
     "failedToRemove": "Failed to remove member",
+    "alreadyInvited": "User already has a pending invite.",
+    "userHasPendingRequest": "User already has a pending join request. Accept it instead.",
+    "alreadyInTeam": "You are already a member of this team.",
     "teamFullTitle": "Team Full",
     "teamFull": "Team is already full",
     "failedToAcceptRequest": "Failed to accept join request",
     "failedToRejectRequest": "Failed to reject join request",
+    "failedToLoadUsers": "Failed to load users",
+    "failedToSendInvite": "Failed to send invite",
+    "userNotFoundOrMember": "User not found or already a member",
+    "failedToFindUser": "Failed to find user",
     "joinRequestRejected": "Join request rejected successfully",
     "joinRequestAccepted": "Join request accepted successfully"
   },
@@ -237,6 +244,7 @@
     "low": "Low",
     "medium": "Medium",
     "high": "High",
+    "pleaseAddDescription": "Please add a description",
     "noTasks": "No tasks found",
     "createFirst": "Create your first task!"
   },
@@ -275,7 +283,8 @@
     "alreadyFriends": "You are already friends.",
     "addFriendFailed": "Failed to send friend request.",
     "userNotFound": "User not found.",
-    "loadUsersFailed": "Failed to load users."
+    "loadUsersFailed": "Failed to load users.",
+    "friendNotFound": "This user is no longer in your friends list."
   },
   "chat": {
     "title": "Chat",

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -41,7 +41,8 @@
       "verificationCode": "Verification Code",
       "verify": "Verify",
       "backToLogin": "Back to Login",
-      "signInWith42": "Sign in with 42"
+      "signInWith42": "Sign in with 42",
+      "userNotFound": "No account found with this email."
     },
     "register": {
       "title": "Register",

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -263,7 +263,11 @@
     "chat": "Discuter",
     "noReceivedRequests": "Aucune demande en attente",
     "noSentRequests": "Aucune demande envoyée en attente",
-    "friendRequestExists": "Une demande d'ami est déjà en attente."
+    "friendRequestExists": "Une demande d'ami est déjà en attente.",
+    "alreadyFriends": "Vous êtes déjà amis.",
+    "addFriendFailed": "Échec de l'envoi de la demande d'ami.",
+    "userNotFound": "Utilisateur non trouvé.",
+    "loadUsersFailed": "Échec du chargement des utilisateurs."
   },
   "chat": {
     "title": "Discussion",

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -41,7 +41,8 @@
       "verificationCode": "Code de vérification",
       "verify": "Vérifier",
       "backToLogin": "Retour à la connexion",
-      "signInWith42": "Se connecter avec 42"
+      "signInWith42": "Se connecter avec 42",
+      "userNotFound": "Aucun compte trouvé avec cet email."
     },
     "register": {
       "title": "Inscription",

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -210,6 +210,9 @@
     "addTask": "Ajouter une tâche",
     "memberRemovedSuccess": "Membre supprimé avec succès",
     "inviteSentSuccess": "Invitation envoyée avec succès",
+    "alreadyInvited": "L'utilisateur a déjà une invitation en attente.",
+    "userHasPendingRequest": "L'utilisateur a déjà une demande d'adhésion en attente. Acceptez-la plutôt.",
+    "alreadyInTeam": "Vous êtes déjà membre de cette équipe.",
     "editTeam": "Modifier l'équipe",
     "saveSettings": "Enregistrer les modifications",
     "settingsUpdated": "Paramètres de l'équipe mis à jour",
@@ -218,6 +221,10 @@
     "teamFull": "L'équipe est déjà complète",
     "failedToAcceptRequest": "Échec de l'acceptation de la demande d'adhésion",
     "failedToRejectRequest": "Échec du refus de la demande d'adhésion",
+    "failedToLoadUsers": "Échec du chargement des utilisateurs",
+    "failedToSendInvite": "Échec de l'envoi de l'invitation",
+    "userNotFoundOrMember": "Utilisateur non trouvé ou déjà membre",
+    "failedToFindUser": "Échec de la recherche de l'utilisateur",
     "joinRequestRejected": "Demande d'adhésion refusée avec succès",
     "joinRequestAccepted": "Demande d'adhésion acceptée avec succès"
   },
@@ -239,6 +246,7 @@
     "low": "Basse",
     "medium": "Moyenne",
     "high": "Haute",
+    "pleaseAddDescription": "Veuillez ajouter une description",
     "noTasks": "Aucune tâche trouvée",
     "createFirst": "Créez votre première tâche !"
   },

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -331,7 +331,8 @@
     "teamInviteRejected": "{{username}} a refusé votre invitation à rejoindre {{team}}.",
     "teamRemoved": "Vous avez été retiré de l'équipe {{team}}.",
     "teamUserLeft": "{{username}} a quitté {{team}}.",
-    "teamDeleted": "L'équipe {{team}} a été supprimée par son propriétaire."
+    "teamDeleted": "L'équipe {{team}} a été supprimée par son propriétaire.",
+    "teamLoadFailed": "Échec du chargement des informations de l'équipe."
   },
   "legal": {
     "privacy": {

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -210,6 +210,9 @@
     "addTask": "Adicionar Tarefa",
     "memberRemovedSuccess": "Membro removido com sucesso",
     "inviteSentSuccess": "Convite enviado com sucesso",
+    "alreadyInvited": "O utilizador já tem um convite pendente.",
+    "userHasPendingRequest": "O utilizador já tem um pedido de entrada pendente. Aceite-o em vez de convidar.",
+    "alreadyInTeam": "Você já é um membro desta equipa.",
     "editTeam": "Editar equipa",
     "saveSettings": "Guardar alterações",
     "settingsUpdated": "Configurações da equipa atualizadas",
@@ -218,6 +221,10 @@
     "teamFull": "A equipa já está cheia",
     "failedToAcceptRequest": "Falha ao aceitar pedido de entrada",
     "failedToRejectRequest": "Falha ao rejeitar pedido de entrada",
+    "failedToLoadUsers": "Falha ao carregar utilizadores",
+    "failedToSendInvite": "Falha ao enviar convite",
+    "userNotFoundOrMember": "Utilizador não encontrado ou já é membro",
+    "failedToFindUser": "Falha ao encontrar utilizador",
     "joinRequestRejected": "Pedido de entrada rejeitado com sucesso",
     "joinRequestAccepted": "Pedido de entrada aceite com sucesso"
   },
@@ -239,6 +246,7 @@
     "low": "Baixa",
     "medium": "Média",
     "high": "Alta",
+    "pleaseAddDescription": "Por favor, adicione uma descrição",
     "noTasks": "Nenhuma tarefa encontrada",
     "createFirst": "Crie a sua primeira tarefa!"
   },
@@ -267,7 +275,8 @@
     "alreadyFriends": "Já são amigos.",
     "addFriendFailed": "Falha ao enviar pedido de amizade.",
     "userNotFound": "Utilizador não encontrado.",
-    "loadUsersFailed": "Falha ao carregar utilizadores."
+    "loadUsersFailed": "Falha ao carregar utilizadores.",
+    "friendNotFound": "Este utilizador já não está na sua lista de amigos."
   },
   "chat": {
     "title": "Chat",

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -262,7 +262,11 @@
     "chat": "Conversar",
     "noReceivedRequests": "Sem pedidos pendentes",
     "noSentRequests": "Sem pedidos enviados pendentes",
-    "friendRequestExists": "Já existe um pedido de amizade pendente."
+    "friendRequestExists": "Já existe um pedido de amizade pendente.",
+    "alreadyFriends": "Já são amigos.",
+    "addFriendFailed": "Falha ao enviar pedido de amizade.",
+    "userNotFound": "Utilizador não encontrado.",
+    "loadUsersFailed": "Falha ao carregar utilizadores."
   },
   "chat": {
     "title": "Chat",

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -41,7 +41,8 @@
       "verificationCode": "Código de Verificação",
       "verify": "Verificar",
       "backToLogin": "Voltar ao Login",
-      "signInWith42": "Entrar com 42"
+      "signInWith42": "Entrar com 42",
+      "userNotFound": "Nenhuma conta encontrada com este email."
     },
     "register": {
       "title": "Registar",

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -330,7 +330,8 @@
     "teamInviteRejected": "{{username}} recusou o seu convite para entrar em {{team}}.",
     "teamRemoved": "Foi removido da equipa {{team}}.",
     "teamUserLeft": "{{username}} saiu de {{team}}.",
-    "teamDeleted": "A equipa {{team}} foi eliminada pelo seu proprietário."
+    "teamDeleted": "A equipa {{team}} foi eliminada pelo seu proprietário.",
+    "teamLoadFailed": "Falha ao carregar informações da equipa."
   },
   "legal": {
     "privacy": {

--- a/project/frontend/application/src/pages/auth/Login.tsx
+++ b/project/frontend/application/src/pages/auth/Login.tsx
@@ -37,14 +37,12 @@ function Login() {
 
     if (USE_MOCK) {
       try {
-        console.log('Login:', { email, password });
         const data = { requires2FA: false, tempToken: 'mock-temp-token' };
 
         if (data.requires2FA) {
           setTempToken(data.tempToken);
           setShow2FA(true);
         } else {
-          console.log('Login successful, user data:', data.user);
           window.location.href = '/';
         }
       } catch {
@@ -72,7 +70,6 @@ function Login() {
     setLoading(true);
 
     try {
-      console.log('Verifying 2FA code:', { tempToken, code: twoFactorCode });
       window.location.href = '/';
     } catch {
       setError('Invalid verification code. Please try again.');

--- a/project/frontend/application/src/pages/auth/Login.tsx
+++ b/project/frontend/application/src/pages/auth/Login.tsx
@@ -21,7 +21,7 @@ import { api } from '../../services/api';
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
 
 function Login() {
-  const { t } = useTranslation();
+  const { t } = useTranslation(undefined, { lng: 'en' });
   const navigate = useNavigate();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -53,6 +53,12 @@ function Login() {
     } else {
       setLoading(true);
       try {
+        const { exists } = await api.checkEmail(email);
+        if (!exists) {
+          setError(t('auth.login.userNotFound') || 'No account found with this email.');
+          setLoading(false);
+          return;
+        }
         const result = await api.login({ email, password });
         localStorage.setItem('authToken', result.token);
         window.location.href = '/';

--- a/project/frontend/application/src/pages/auth/Login.tsx
+++ b/project/frontend/application/src/pages/auth/Login.tsx
@@ -63,6 +63,7 @@ function Login() {
         localStorage.setItem('authToken', result.token);
         window.location.href = '/';
       } catch (err: any) {
+        // Prevent default console error reporting for login failures
         setError(err.message || 'Login failed. Please check your credentials.');
       } finally {
         setLoading(false);

--- a/project/frontend/application/src/pages/auth/PrivacyPolicy.tsx
+++ b/project/frontend/application/src/pages/auth/PrivacyPolicy.tsx
@@ -12,8 +12,8 @@ import AuthLayout from '../../components/layouts/AuthLayout';
 import ProfileLayout from '../../components/layouts/ProfileLayout';
 
 function PrivacyPolicy() {
-  const { t } = useTranslation();
   const { user } = useContext(AuthContext);
+  const { t } = useTranslation(undefined, { lng: user ? undefined : 'en' });
 
   const pageContent = (
     <section className="legal-page">

--- a/project/frontend/application/src/pages/auth/Register.tsx
+++ b/project/frontend/application/src/pages/auth/Register.tsx
@@ -23,7 +23,7 @@ import { api } from '../../services/api';
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
 
 function Register() {
-  const { t } = useTranslation();
+  const { t } = useTranslation(undefined, { lng: 'en' });
   const navigate = useNavigate();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');

--- a/project/frontend/application/src/pages/auth/Register.tsx
+++ b/project/frontend/application/src/pages/auth/Register.tsx
@@ -17,6 +17,7 @@ import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import AuthLayout from '../../components/layouts/AuthLayout';
+import { useError } from '../../context/ErrorContext';
 import { api } from '../../services/api';
 
 const USE_MOCK = import.meta.env.VITE_USE_MOCK === 'true';
@@ -29,6 +30,7 @@ function Register() {
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
   const [loading, setLoading] = useState(false);
+  const { showError } = useError();
   const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -69,7 +71,7 @@ function Register() {
         setLoading(false);
       }
     } else {
-      alert('Registration is not yet implemented. Please use the 42 login option.');
+      showError('Info', 'Registration is not yet implemented. Please use the 42 login option.');
     }
   };
 

--- a/project/frontend/application/src/pages/auth/TermsOfService.tsx
+++ b/project/frontend/application/src/pages/auth/TermsOfService.tsx
@@ -12,8 +12,8 @@ import AuthLayout from '../../components/layouts/AuthLayout';
 import ProfileLayout from '../../components/layouts/ProfileLayout';
 
 function TermsOfService() {
-  const { t } = useTranslation();
   const { user } = useContext(AuthContext);
+  const { t } = useTranslation(undefined, { lng: user ? undefined : 'en' });
 
   const pageContent = (
     <section className="legal-page">

--- a/project/frontend/application/src/pages/feed/Feed.tsx
+++ b/project/frontend/application/src/pages/feed/Feed.tsx
@@ -178,23 +178,6 @@ function Feed() {
           baseTeams = teamsData;
         }
 
-        const statusResults = await Promise.all(
-          baseTeams.map(async (team) => {
-            try {
-              const detail = await api.getTeam(team.id);
-              return { id: team.id, isFinished: detail.status === 'finished' };
-            } catch {
-              return { id: team.id, isFinished: false };
-            }
-          })
-        );
-        const finishedIds = new Set(
-          statusResults.filter(r => r.isFinished).map(r => r.id)
-        );
-        if (finishedIds.size > 0) {
-          baseTeams = baseTeams.filter(t => !finishedIds.has(t.id));
-        }
-
         setTeams(baseTeams);
         setIsUsingMockData(false);
       } catch {

--- a/project/frontend/application/src/pages/feed/Feed.tsx
+++ b/project/frontend/application/src/pages/feed/Feed.tsx
@@ -197,8 +197,7 @@ function Feed() {
 
         setTeams(baseTeams);
         setIsUsingMockData(false);
-      } catch (err) {
-        console.error('Failed to fetch teams:', err);
+      } catch {
         if (!user) {
           setTeams(MOCK_AVAILABLE_TEAMS);
           setIsUsingMockData(true);

--- a/project/frontend/application/src/pages/feed/Feed.tsx
+++ b/project/frontend/application/src/pages/feed/Feed.tsx
@@ -98,7 +98,7 @@ const MOCK_AVAILABLE_TEAMS: Team[] = [
 
 function Feed() {
   const { t } = useTranslation();
-  const { user } = useContext(AuthContext);
+  const { user, teamInvites } = useContext(AuthContext)!;
   const [teams, setTeams] = useState<Team[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -123,17 +123,23 @@ function Feed() {
     const fetchTeams = async () => {
       try {
         setLoading(true);
-        const teamsData = await api.getTeams();
+        const [teamsData, invites] = await Promise.all([
+          api.getTeams(),
+          user ? api.getTeamInvites() : Promise.resolve([])
+        ]);
 
         let baseTeams: Team[];
 
         if (user) {
           const myTeams = await api.getMyTeams();
           const myTeamIds = new Set(myTeams.map(t => t.id));
+          const invitedTeamIds = new Set(invites.map(i => i.team_id));
 
           setRequestStatuses(prev => {
             const next = { ...prev };
             let changed = false;
+            
+            // Remove pending if already a member
             const pendingIds = Object.keys(next).filter(k => next[Number(k)] === 'pending').map(Number);
             for (const teamId of pendingIds) {
               if (myTeamIds.has(teamId)) {
@@ -141,15 +147,25 @@ function Feed() {
                 changed = true;
               }
             }
+
+            // Sync with existing invites (if invited, mark as pending to disable Join button)
+            for (const teamId of Array.from(invitedTeamIds)) {
+              if (!next[teamId]) {
+                next[teamId] = 'pending';
+                changed = true;
+              }
+            }
+
             return changed ? next : prev;
           });
 
           baseTeams = teamsData.filter(t => !myTeamIds.has(t.id));
-
+          
+          // Remaining logic for join requests verification...
           const rawPendingIds = Object.keys(requestStatuses)
             .filter(k => requestStatuses[Number(k)] === 'pending')
             .map(Number);
-          const pendingIds = rawPendingIds.filter(id => !myTeamIds.has(id));
+          const pendingIds = rawPendingIds.filter(id => !myTeamIds.has(id) && !invitedTeamIds.has(id));
           if (pendingIds.length > 0) {
             const results = await Promise.all(
               pendingIds.map(async (teamId) => {
@@ -166,7 +182,7 @@ function Feed() {
               const next = { ...prev };
               let changed = false;
               for (const { teamId, valid } of results) {
-                if (!valid && next[teamId] === 'pending') {
+                if (!valid && next[teamId] === 'pending' && !invitedTeamIds.has(teamId)) {
                   delete next[teamId];
                   changed = true;
                 }
@@ -180,12 +196,15 @@ function Feed() {
 
         setTeams(baseTeams);
         setIsUsingMockData(false);
-      } catch {
+      } catch (err) {
         if (!user) {
           setTeams(MOCK_AVAILABLE_TEAMS);
           setIsUsingMockData(true);
         } else {
-          setError('Failed to load teams');
+          // Suppress error log if it's a silent auth failure
+          if (!(err instanceof Error && err.message.includes('401'))) {
+            setError('Failed to load teams');
+          }
         }
       } finally {
         setLoading(false);
@@ -212,6 +231,47 @@ function Feed() {
       setShowNotification(true);
       return;
     }
+
+    // Guard: Check if user already has a pending invite for this team
+    const hasPendingInvite = (teamInvites || []).some(invite => invite.team_id === teamId && invite.status === 'pending');
+    if (hasPendingInvite) {
+      setRequestStatuses(prev => ({ ...prev, [teamId]: 'pending' }));
+      setNotificationType('info');
+      setNotificationMessage(t('teams.alreadyInvited') || 'You already have a pending invite for this team. Check your invitations.');
+      setShowNotification(true);
+      return;
+    }
+
+    // Guard: Check if user is already a member (in case of stale state)
+    try {
+      const myTeams = await api.getMyTeams();
+      if (myTeams.some(t => t.id === teamId)) {
+        setNotificationType('info');
+        setNotificationMessage(t('teams.alreadyInTeam') || 'You are already a member of this team.');
+        setShowNotification(true);
+        // Refresh local state if possible
+        setTeams(prev => prev.filter(t => t.id !== teamId));
+        return;
+      }
+    } catch {
+      // Ignore myTeams fetch error and proceed
+    }
+
+    // Guard: Fetch latest invites from server to avoid stale context
+    try {
+      const latestInvites = await api.getTeamInvites();
+      const hasInvite = latestInvites.some((invite: any) => invite.team_id === teamId);
+      if (hasInvite) {
+        setRequestStatuses(prev => ({ ...prev, [teamId]: 'pending' }));
+        setNotificationType('info');
+        setNotificationMessage(t('teams.alreadyInvited') || 'You already have a pending invite for this team. Check your invitations.');
+        setShowNotification(true);
+        return;
+      }
+    } catch {
+      // Ignore invite fetch error and proceed with join request
+    }
+
     try {
       await api.sendJoinRequest(teamId);
       setRequestStatuses(prev => ({ ...prev, [teamId]: 'pending' }));
@@ -220,10 +280,14 @@ function Feed() {
       setShowNotification(true);
     } catch (err: any) {
       const message = err?.message || '';
-      if (message.includes('already exists')) {
+      if (message.includes('already exists') || message.includes('already have a pending invite')) {
         setRequestStatuses(prev => ({ ...prev, [teamId]: 'pending' }));
         setNotificationType('info');
-        setNotificationMessage(t('teams.alreadyRequested') || 'You already have a pending request for this team.');
+        if (message.includes('pending invite')) {
+          setNotificationMessage(t('teams.alreadyInvited') || 'You already have a pending invite for this team. Check your invitations.');
+        } else {
+          setNotificationMessage(t('teams.alreadyRequested') || 'You already have a pending request for this team.');
+        }
       } else {
         setNotificationType('error');
         setNotificationMessage(t('teams.joinRequestFailed') || 'Failed to send join request.');
@@ -292,11 +356,11 @@ function Feed() {
                 {t('feed.lookingFor') || 'Looking for'} <strong>{(team.maxUsers || 10) - (team.memberCount || 0)}</strong> {(team.maxUsers || 10) - (team.memberCount || 0) > 1 ? t('feed.collaborators') : t('feed.collaborator')}
               </span>
               <button
-                className={`btn btn-small ${requestStatuses[team.id] === 'pending' && user ? 'btn-pending' : 'btn-primary'}`}
+                className={`btn btn-small ${(requestStatuses[team.id] === 'pending' || (teamInvites || []).some(i => i.team_id === team.id && i.status === 'pending')) && user ? 'btn-pending' : 'btn-primary'}`}
                 onClick={() => handleJoinTeam(team.id, team.name)}
-                disabled={requestStatuses[team.id] === 'pending' && !!user}
+                disabled={(requestStatuses[team.id] === 'pending' || (teamInvites || []).some(i => i.team_id === team.id && i.status === 'pending')) && !!user}
               >
-                {requestStatuses[team.id] === 'pending' && user ? t('teams.pending') : t('teams.join')}
+                {(requestStatuses[team.id] === 'pending' || (teamInvites || []).some(i => i.team_id === team.id && i.status === 'pending')) && user ? t('teams.pending') : t('teams.join')}
               </button>
             </div>
           </div>

--- a/project/frontend/application/src/pages/profile/Friends.tsx
+++ b/project/frontend/application/src/pages/profile/Friends.tsx
@@ -9,6 +9,7 @@ import { useContext, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
+import { useError } from '../../context/ErrorContext';
 import { api } from '../../services/api';
 import { getAvatarUrl } from '../../utils/avatar';
 import type { Friend } from '../../types';
@@ -20,6 +21,7 @@ interface SearchUser {
 
 function Friends() {
   const { t } = useTranslation();
+  const { showError } = useError();
   const { user, removeFriend, addFriend, friendRequests, sentRequests, friends, acceptFriendRequest, rejectFriendRequest, fetchFriendRequests, fetchSentRequests, fetchFriends } = useContext(AuthContext);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [friendToRemove, setFriendToRemove] = useState<Friend | null>(null);
@@ -28,7 +30,6 @@ function Friends() {
   const [manualUsername, setManualUsername] = useState('');
   const [allUsers, setAllUsers] = useState<SearchUser[]>([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
-  const [errorUsers, setErrorUsers] = useState('');
 
   useEffect(() => {
     fetchFriendRequests();
@@ -44,12 +45,11 @@ function Friends() {
 
   const fetchUsers = async () => {
     setLoadingUsers(true);
-    setErrorUsers('');
     try {
       const users = await api.searchUsers('');
       setAllUsers(users);
     } catch {
-      setErrorUsers('Failed to load users');
+      showError(t('common.error'), t('friends.loadUsersFailed'));
     } finally {
       setLoadingUsers(false);
     }
@@ -91,6 +91,14 @@ function Friends() {
     if (!selectedUser) return;
     const userToAdd = availableUsers.find((u) => u.username === selectedUser);
     if (userToAdd) {
+      if (friends.some((f) => f.id === userToAdd.id)) {
+        showError(t('common.error'), t('friends.alreadyFriends'));
+        return;
+      }
+      if (sentRequests.some((r) => r.user.id === userToAdd.id)) {
+        showError(t('common.error'), t('friends.friendRequestExists'));
+        return;
+      }
       try {
         await api.addFriend(userToAdd.id);
         fetchSentRequests();
@@ -98,7 +106,7 @@ function Friends() {
         setShowAddFriendModal(false);
       } catch (err) {
         const msg = err instanceof Error ? err.message : '';
-        setErrorUsers(msg.includes('already exists') ? t('friends.friendRequestExists') : (msg || 'Failed to send friend request'));
+        showError(t('common.error'), msg || t('friends.addFriendFailed'));
       }
     }
   };
@@ -106,23 +114,30 @@ function Friends() {
   const handleAddManual = async () => {
     if (!manualUsername.trim()) return;
     setLoadingUsers(true);
-    setErrorUsers('');
     try {
       const users = await api.searchUsers(manualUsername.trim());
       const foundUser = users.find(
         (u) => u.username.toLowerCase() === manualUsername.trim().toLowerCase()
       );
       if (foundUser) {
+        if (friends.some((f) => f.id === foundUser.id)) {
+          showError(t('common.error'), t('friends.alreadyFriends'));
+          return;
+        }
+        if (sentRequests.some((r) => r.user.id === foundUser.id)) {
+          showError(t('common.error'), t('friends.friendRequestExists'));
+          return;
+        }
         await api.addFriend(foundUser.id);
         fetchSentRequests();
         setManualUsername('');
         setShowAddFriendModal(false);
       } else {
-        setErrorUsers('User not found');
+        showError(t('common.error'), t('friends.userNotFound'));
       }
     } catch (err) {
       const msg = err instanceof Error ? err.message : '';
-      setErrorUsers(msg.includes('already exists') ? t('friends.friendRequestExists') : (msg || 'Failed to send friend request'));
+      showError(t('common.error'), msg || t('friends.addFriendFailed'));
     } finally {
       setLoadingUsers(false);
     }
@@ -300,8 +315,6 @@ function Friends() {
                   </button>
                 </div>
               </div>
-
-              {errorUsers && <p className="error-text">{errorUsers}</p>}
 
               {availableUsers.length === 0 && friends.length > 0 && !loadingUsers && (
                 <p className="empty-hint text-center">{t('friends.noUsersToAdd') || 'No users available to add'}</p>

--- a/project/frontend/application/src/pages/profile/Friends.tsx
+++ b/project/frontend/application/src/pages/profile/Friends.tsx
@@ -76,11 +76,19 @@ function Friends() {
 
   const handleConfirmRemove = async () => {
     if (friendToRemove) {
+      // Pre-check: verify friend still exists in our list
+      if (!friends.some(f => f.id === friendToRemove.id)) {
+        showError(t('common.error'), t('friends.friendNotFound') || 'This user is no longer in your friends list.');
+        setShowRemoveModal(false);
+        setFriendToRemove(null);
+        return;
+      }
+
       try {
         await api.removeFriend(friendToRemove.id);
-        removeFriend(friendToRemove.id);
         fetchFriends();
-      } catch {
+      } catch (err: any) {
+        showError(t('common.error'), err?.message || t('friends.failedToRemove') || 'Failed to remove friend');
       }
       setShowRemoveModal(false);
       setFriendToRemove(null);

--- a/project/frontend/application/src/pages/profile/Friends.tsx
+++ b/project/frontend/application/src/pages/profile/Friends.tsx
@@ -48,9 +48,8 @@ function Friends() {
     try {
       const users = await api.searchUsers('');
       setAllUsers(users);
-    } catch (err) {
+    } catch {
       setErrorUsers('Failed to load users');
-      console.error(err);
     } finally {
       setLoadingUsers(false);
     }
@@ -81,8 +80,7 @@ function Friends() {
         await api.removeFriend(friendToRemove.id);
         removeFriend(friendToRemove.id);
         fetchFriends();
-      } catch (err) {
-        console.error('Failed to remove friend:', err);
+      } catch {
       }
       setShowRemoveModal(false);
       setFriendToRemove(null);
@@ -101,7 +99,6 @@ function Friends() {
       } catch (err) {
         const msg = err instanceof Error ? err.message : '';
         setErrorUsers(msg.includes('already exists') ? t('friends.friendRequestExists') : (msg || 'Failed to send friend request'));
-        console.error(err);
       }
     }
   };
@@ -126,7 +123,6 @@ function Friends() {
     } catch (err) {
       const msg = err instanceof Error ? err.message : '';
       setErrorUsers(msg.includes('already exists') ? t('friends.friendRequestExists') : (msg || 'Failed to send friend request'));
-      console.error(err);
     } finally {
       setLoadingUsers(false);
     }

--- a/project/frontend/application/src/pages/profile/Notifications.tsx
+++ b/project/frontend/application/src/pages/profile/Notifications.tsx
@@ -146,23 +146,25 @@ function Notifications() {
     const teamName = extractTeamName(notification.type, notification.content);
     if (teamName) {
       try {
-        const teams = await api.getTeams();
-        const team = teams.find(t => t.name === teamName);
-        if (team) {
-          const membersData = await api.getTeamMembers(team.id);
-          const isMember = user?.id != null && membersData.member_list.some(m => m.id === user.id);
+        const teamsData = await api.getTeams();
+        const foundTeam = teamsData.find(t => t.name === teamName);
+        
+        if (foundTeam) {
+          // Check if user is already a member using api.getMyTeams for authoritative list
+          const myTeams = await api.getMyTeams();
+          const isMember = myTeams.some(mt => mt.id === foundTeam.id);
+          
           if (isMember) {
-            navigate(`/teams/${team.id}`);
+            navigate(`/teams/${foundTeam.id}`);
           } else {
-            showError(t('common.error'), t('teams.notFoundDesc'));
+            // Not a member yet, redirect to team list
             navigate('/profile/teams');
           }
         } else {
-          showError(t('common.error'), t('teams.notFoundDesc'));
           navigate('/profile/teams');
         }
-      } catch {
-        showError(t('common.error'), t('notifications.teamLoadFailed'));
+      } catch (err) {
+        console.error('Notification navigation failed:', err);
         navigate('/profile/teams');
       }
     } else {

--- a/project/frontend/application/src/pages/profile/Notifications.tsx
+++ b/project/frontend/application/src/pages/profile/Notifications.tsx
@@ -2,6 +2,7 @@ import { useContext, useEffect } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
+import { useError } from '../../context/ErrorContext';
 import { api } from '../../services/api';
 import type { AppNotification } from '../../types';
 
@@ -134,6 +135,7 @@ function isTeamType(type: string): boolean {
 function Notifications() {
   const { t } = useTranslation();
   const navigate = useNavigate();
+  const { showError } = useError();
   const { user, notifications, fetchNotifications, deleteAllNotifications, deleteNotification, markAsRead } = useContext(AuthContext);
 
   useEffect(() => {
@@ -149,11 +151,18 @@ function Notifications() {
         if (team) {
           const membersData = await api.getTeamMembers(team.id);
           const isMember = user?.id != null && membersData.member_list.some(m => m.id === user.id);
-          navigate(isMember ? `/teams/${team.id}` : '/profile/teams');
+          if (isMember) {
+            navigate(`/teams/${team.id}`);
+          } else {
+            showError(t('common.error'), t('teams.notFoundDesc'));
+            navigate('/profile/teams');
+          }
         } else {
+          showError(t('common.error'), t('teams.notFoundDesc'));
           navigate('/profile/teams');
         }
       } catch {
+        showError(t('common.error'), t('notifications.teamLoadFailed'));
         navigate('/profile/teams');
       }
     } else {

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -461,9 +461,7 @@ function TeamDetail() {
         setShowSuccessModal(true);
       } catch (err: any) {
         if (err?.message?.includes('already exists')) {
-          setSuccessMessage(t('teams.alreadyInvited') || 'User already has a pending invite.');
-          setShowSuccessModal(true);
-          setShowAddMemberModal(false);
+          setErrorUsers(t('teams.alreadyInvited') || 'User already has a pending invite.');
         } else {
           setErrorUsers(t('teams.failedToSendInvite') || 'Failed to send invite');
         }
@@ -507,9 +505,7 @@ function TeamDetail() {
           setShowSuccessModal(true);
         } catch (err: any) {
           if (err?.message?.includes('already exists')) {
-            setSuccessMessage(t('teams.alreadyInvited') || 'User already has a pending invite.');
-            setShowSuccessModal(true);
-            setShowAddMemberModal(false);
+            setErrorUsers(t('teams.alreadyInvited') || 'User already has a pending invite.');
           } else {
             setErrorUsers(t('teams.failedToSendInvite') || 'Failed to send invite');
           }

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -164,9 +164,9 @@ function TeamDetail() {
     try {
       const users = await api.searchUsers('');
       setAllUsers(users);
-    } catch {
-      setErrorUsers('Failed to load users');
-    } finally {
+      } catch {
+      setErrorUsers(t('teams.failedToLoadUsers') || 'Failed to load users');
+      } finally {
       setLoadingUsers(false);
     }
   };
@@ -331,7 +331,17 @@ function TeamDetail() {
 
   const handleAddTask = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!newTask.title.trim() || !canEdit) return;
+    if (!canEdit) return;
+    if (!newTask.title.trim()) {
+      showError(t('common.error'), t('teams.taskTitleRequired') || 'Title is required');
+      return;
+    }
+    
+    if (!newTask.description.trim()) {
+      showError(t('common.error'), t('tasks.pleaseAddDescription') || 'Please add a description');
+      return;
+    }
+
     try {
       const members = team.members.filter((m: Member) => newTask.assignedTo.includes(m.username));
       const createdTask = await api.createTask(team.id, {
@@ -343,7 +353,8 @@ function TeamDetail() {
       setTasks([...tasks, createdTask]);
       setNewTask({ title: '', description: '', assignedTo: [], status: 'open' });
       setShowTaskForm(false);
-    } catch {
+    } catch (err: any) {
+      showError(t('common.error'), err.message || t('tasks.failedToCreate') || 'Failed to create task');
     }
   };
 
@@ -433,18 +444,30 @@ function TeamDetail() {
     }
     const userToAdd = availableUsers.find((u) => u.username === selectedFriend);
     if (userToAdd) {
-      try {
-        await api.sendTeamInvite(team.id, userToAdd.id);
-      } catch {
-        setErrorUsers('Failed to send invite');
+      // Guard: Check if user already has a pending join request
+      if (joinRequests.some(r => r.user_id === userToAdd.id)) {
+        setErrorUsers(t('teams.userHasPendingRequest') || 'User already has a pending join request. Accept it instead.');
         return;
       }
-      addTeamMember(team.id, { id: userToAdd.id, username: userToAdd.username, avatar: userToAdd.avatar, role: 'Member' }, 'Member');
-      setSelectedFriend('');
-      setShowAddMemberModal(false);
-      setSuccessMessage(t('teams.inviteSentSuccess'));
-      setSuccessReload(false);
-      setShowSuccessModal(true);
+      try {
+        // Pre-check for pending invites to this user if possible or handle catch gracefully
+        await api.sendTeamInvite(team.id, userToAdd.id);
+        
+        addTeamMember(team.id, { id: userToAdd.id, username: userToAdd.username, avatar: userToAdd.avatar, role: 'Member' }, 'Member');
+        setSelectedFriend('');
+        setShowAddMemberModal(false);
+        setSuccessMessage(t('teams.inviteSentSuccess'));
+        setSuccessReload(false);
+        setShowSuccessModal(true);
+      } catch (err: any) {
+        if (err?.message?.includes('already exists')) {
+          setSuccessMessage(t('teams.alreadyInvited') || 'User already has a pending invite.');
+          setShowSuccessModal(true);
+          setShowAddMemberModal(false);
+        } else {
+          setErrorUsers(t('teams.failedToSendInvite') || 'Failed to send invite');
+        }
+      }
     }
   };
 
@@ -462,28 +485,40 @@ function TeamDetail() {
         (u) => u.username.toLowerCase() === manualUsername.trim().toLowerCase()
       );
       if (foundUser && !team.members.some((m) => m.id === foundUser.id)) {
-        try {
-          await api.sendTeamInvite(team.id, foundUser.id);
-        } catch {
-          setErrorUsers('Failed to send invite');
+        // Guard: Check if user already has a pending join request
+        if (joinRequests.some(r => r.user_id === foundUser.id)) {
+          setErrorUsers(t('teams.userHasPendingRequest') || 'User already has a pending join request. Accept it instead.');
+          setLoadingUsers(false);
           return;
         }
-        addTeamMember(team.id, {
-          id: foundUser.id,
-          username: foundUser.username,
-          avatar: getAvatarUrl(u.avatar_url),
-          role: 'Member',
-        }, 'Member');
-        setManualUsername('');
-        setShowAddMemberModal(false);
-        setSuccessMessage(t('teams.inviteSentSuccess'));
-        setSuccessReload(false);
-        setShowSuccessModal(true);
+        try {
+          await api.sendTeamInvite(team.id, foundUser.id);
+          
+          addTeamMember(team.id, {
+            id: foundUser.id,
+            username: foundUser.username,
+            avatar: getAvatarUrl(foundUser.avatar_url),
+            role: 'Member',
+          }, 'Member');
+          setManualUsername('');
+          setShowAddMemberModal(false);
+          setSuccessMessage(t('teams.inviteSentSuccess'));
+          setSuccessReload(false);
+          setShowSuccessModal(true);
+        } catch (err: any) {
+          if (err?.message?.includes('already exists')) {
+            setSuccessMessage(t('teams.alreadyInvited') || 'User already has a pending invite.');
+            setShowSuccessModal(true);
+            setShowAddMemberModal(false);
+          } else {
+            setErrorUsers(t('teams.failedToSendInvite') || 'Failed to send invite');
+          }
+        }
       } else {
-        setErrorUsers('User not found or already a member');
+        setErrorUsers(t('teams.userNotFoundOrMember') || 'User not found or already a member');
       }
     } catch {
-      setErrorUsers('Failed to find user');
+      setErrorUsers(t('teams.failedToFindUser') || 'Failed to find user');
     } finally {
       setLoadingUsers(false);
     }
@@ -581,7 +616,12 @@ function TeamDetail() {
               </button>
             )}
             {isLeader && (
-              <button className="btn btn-primary btn-small" onClick={() => setShowAddMemberModal(true)}>
+              <button className="btn btn-primary btn-small" onClick={() => {
+                setShowAddMemberModal(true);
+                setErrorUsers('');
+                setManualUsername('');
+                setSelectedFriend('');
+              }}>
                 + {t('teams.addMember') || 'Add Member'}
               </button>
             )}
@@ -671,7 +711,6 @@ function TeamDetail() {
               className="input"
               value={newTask.title}
               onChange={(e) => setNewTask({ ...newTask, title: e.target.value })}
-              required
             />
             <textarea
               placeholder={t('tasks.description')}

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -14,6 +14,7 @@ import { useContext, useState, useEffect, useRef } from 'react';
 import { useParams, useNavigate, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
+import { useError } from '../../context/ErrorContext';
 import { api } from '../../services/api';
 import { getAvatarUrl } from '../../utils/avatar';
 import { ALLOWED_TASK_EXTENSIONS } from '../../utils/fileValidation';
@@ -28,6 +29,7 @@ function TeamDetail() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const { showError } = useError();
   const { user, leaveTeam, addChatMessage, updateTaskStatus, addTask, uploadFile, deleteTaskFile, updateTaskAssignee, addTeamMember, findUserByUsername, removeTeamMember, updateTeamStatus, updateTeamSettings, fetchNotifications, teamRefreshTrigger } = useContext(AuthContext);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -79,8 +81,7 @@ function TeamDetail() {
         setLoadingTeam(true);
         const teamData = await api.getTeam(parseInt(id));
         setTeam(teamData);
-      } catch (err) {
-        console.error('Failed to fetch team:', err);
+      } catch {
         setTeamError('Failed to load team');
       } finally {
         setLoadingTeam(false);
@@ -95,8 +96,7 @@ function TeamDetail() {
       try {
         const data = await api.getJoinRequests(parseInt(id));
         setJoinRequests(data.request_list || []);
-      } catch (err) {
-        console.error('Failed to fetch join requests:', err);
+      } catch {
       }
     };
     fetchJoinRequests();
@@ -118,8 +118,7 @@ function TeamDetail() {
           })
         );
         setTasks(tasksWithFiles);
-      } catch (err) {
-        console.error('Failed to fetch tasks:', err);
+      } catch {
       }
     };
     fetchTasks();
@@ -165,9 +164,8 @@ function TeamDetail() {
     try {
       const users = await api.searchUsers('');
       setAllUsers(users);
-    } catch (err) {
+    } catch {
       setErrorUsers('Failed to load users');
-      console.error(err);
     } finally {
       setLoadingUsers(false);
     }
@@ -233,9 +231,8 @@ function TeamDetail() {
     try {
       await api.deleteTeam(team.id);
       navigate('/profile/teams');
-    } catch (err) {
-      console.error('Failed to delete team:', err);
-      alert('Failed to delete team');
+    } catch {
+      showError('Error', 'Failed to delete team');
     }
   };
 
@@ -289,9 +286,8 @@ function TeamDetail() {
       setSuccessMessage(t('teams.settingsUpdated'));
       setSuccessReload(false);
       setShowSuccessModal(true);
-    } catch (err) {
-      console.error('Failed to update team settings:', err);
-      alert('Failed to update team settings');
+    } catch {
+      showError('Error', 'Failed to update team settings');
     }
   };
 
@@ -315,9 +311,8 @@ function TeamDetail() {
       setSuccessReload(false);
       setShowSuccessModal(true);
       fetchNotifications();
-    } catch (err) {
-      console.error('Failed to accept join request:', err);
-      alert(t('teams.failedToAcceptRequest'));
+    } catch {
+      showError('Error', t('teams.failedToAcceptRequest'));
     }
   };
 
@@ -329,9 +324,8 @@ function TeamDetail() {
       setSuccessReload(false);
       setShowSuccessModal(true);
       fetchNotifications();
-    } catch (err) {
-      console.error('Failed to reject join request:', err);
-      alert(t('teams.failedToRejectRequest'));
+    } catch {
+      showError('Error', t('teams.failedToRejectRequest'));
     }
   };
 
@@ -349,8 +343,7 @@ function TeamDetail() {
       setTasks([...tasks, createdTask]);
       setNewTask({ title: '', description: '', assignedTo: [], status: 'open' });
       setShowTaskForm(false);
-    } catch (err) {
-      console.error('Failed to create task:', err);
+    } catch {
     }
   };
 
@@ -360,8 +353,7 @@ function TeamDetail() {
       const updatedTask = await api.updateTaskStatus(taskId, newStatus);
       setTasks(tasks.map((t) => t.id === taskId ? updatedTask : t));
       updateTaskStatus(team.id, taskId, newStatus);
-    } catch (err) {
-      console.error('Failed to update task status:', err);
+    } catch {
     }
   };
 
@@ -372,8 +364,7 @@ function TeamDetail() {
       await api.updateTaskUsers(taskId, memberIds);
       setTasks(tasks.map((t) => t.id === taskId ? { ...t, assignedTo: selectedMembers.map(m => ({ id: m.id, username: m.username })) } : t));
       updateTaskAssignee(team.id, taskId, selectedMembers);
-    } catch (err) {
-      console.error('Failed to update task users:', err);
+    } catch {
     }
   };
 
@@ -383,8 +374,7 @@ function TeamDetail() {
       await Promise.all(files.map((f) => api.deleteTaskFile(f.id)));
       await api.deleteTask(taskId);
       setTasks(tasks.filter((t) => t.id !== taskId));
-    } catch (err) {
-      console.error('Failed to delete task:', err);
+    } catch {
     }
   };
 
@@ -492,9 +482,8 @@ function TeamDetail() {
       } else {
         setErrorUsers('User not found or already a member');
       }
-    } catch (err) {
+    } catch {
       setErrorUsers('Failed to find user');
-      console.error(err);
     } finally {
       setLoadingUsers(false);
     }
@@ -513,9 +502,8 @@ function TeamDetail() {
       setSuccessMessage(t('teams.memberRemovedSuccess'));
       setSuccessReload(true);
       setShowSuccessModal(true);
-    } catch (err) {
-      console.error('Failed to remove member:', err);
-      alert(t('teams.failedToRemove') || 'Failed to remove member');
+    } catch {
+      showError('Error', t('teams.failedToRemove') || 'Failed to remove member');
     }
   };
 
@@ -531,8 +519,7 @@ function TeamDetail() {
       const url = URL.createObjectURL(blob);
       window.open(url, '_blank');
       setTimeout(() => URL.revokeObjectURL(url), 60_000);
-    } catch (err) {
-      console.error('Download failed:', err);
+    } catch {
     } finally {
       setDownloadingFileId(null);
     }

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -63,6 +63,7 @@ function TeamDetail() {
   const [teamError, setTeamError] = useState('');
   const [tasks, setTasks] = useState<any[]>([]);
   const [joinRequests, setJoinRequests] = useState<any[]>([]);
+  const [teamInvitesSent, setTeamInvitesSent] = useState<any[]>([]);
   const [showFileError, setShowFileError] = useState(false);
   const [fileErrorMessage, setFileErrorMessage] = useState('');
   const [showDeleteTaskConfirm, setShowDeleteTaskConfirm] = useState(false);
@@ -103,6 +104,18 @@ function TeamDetail() {
   }, [id, team?.role, teamRefreshTrigger]);
 
   useEffect(() => {
+    const fetchTeamInvitesSent = async () => {
+      if (!id || team?.role !== 'Leader') return;
+      try {
+        const data = await api.getTeamInvitesSent(parseInt(id));
+        setTeamInvitesSent(data || []);
+      } catch {
+      }
+    };
+    fetchTeamInvitesSent();
+  }, [id, team?.role, teamRefreshTrigger, showAddMemberModal]);
+
+  useEffect(() => {
     const fetchTasks = async () => {
       if (!id) return;
       try {
@@ -125,7 +138,7 @@ function TeamDetail() {
   }, [id, teamRefreshTrigger]);
 
   useEffect(() => {
-    if (showAddMemberModal && allUsers.length === 0) {
+    if (showAddMemberModal) {
       fetchUsers();
     }
   }, [showAddMemberModal]);
@@ -203,6 +216,7 @@ function TeamDetail() {
   const availableUsers = allUsers
     .filter((u) => u.id !== user.id)
     .filter((u) => !team.members.some((m) => m.id === u.id))
+    .filter((u) => !teamInvitesSent.some((inv) => inv.user_id === u.id))
     .map((u) => ({
       id: u.id,
       username: u.username,
@@ -449,8 +463,11 @@ function TeamDetail() {
         setErrorUsers(t('teams.userHasPendingRequest') || 'User already has a pending join request. Accept it instead.');
         return;
       }
+      if (teamInvitesSent.some(inv => inv.user_id === userToAdd.id)) {
+        setErrorUsers(t('teams.alreadyInvited') || 'User already has a pending invite.');
+        return;
+      }
       try {
-        // Pre-check for pending invites to this user if possible or handle catch gracefully
         await api.sendTeamInvite(team.id, userToAdd.id);
         
         addTeamMember(team.id, { id: userToAdd.id, username: userToAdd.username, avatar: userToAdd.avatar, role: 'Member' }, 'Member');
@@ -486,6 +503,11 @@ function TeamDetail() {
         // Guard: Check if user already has a pending join request
         if (joinRequests.some(r => r.user_id === foundUser.id)) {
           setErrorUsers(t('teams.userHasPendingRequest') || 'User already has a pending join request. Accept it instead.');
+          setLoadingUsers(false);
+          return;
+        }
+        if (teamInvitesSent.some(inv => inv.user_id === foundUser.id)) {
+          setErrorUsers(t('teams.alreadyInvited') || 'User already has a pending invite.');
           setLoadingUsers(false);
           return;
         }

--- a/project/frontend/application/src/pages/profile/Teams.tsx
+++ b/project/frontend/application/src/pages/profile/Teams.tsx
@@ -9,6 +9,7 @@ import { useContext, useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
+import { useError } from '../../context/ErrorContext';
 import { api, Team } from '../../services/api';
 
 const TEAM_DETAILS = [
@@ -26,6 +27,7 @@ const TEAM_DETAILS = [
 
 function Teams() {
   const { t } = useTranslation();
+  const { showError } = useError();
   const { user, createTeam, teamInvites, fetchTeamInvites, acceptTeamInvite, rejectTeamInvite, teamRefreshTrigger } = useContext(AuthContext);
   const [error, setError] = useState('');
   const [showCreateModal, setShowCreateModal] = useState(false);
@@ -73,9 +75,8 @@ function Teams() {
         details: newTeam.details,
       });
       api.getMyTeams().then((myTeams) => setTeams(myTeams)).catch(() => {});
-    } catch (err) {
-      console.error('Failed to create team:', err);
-      alert('Failed to create team');
+    } catch {
+      showError('Error', 'Failed to create team');
     }
     setNewTeam({ name: '', description: '', lookingFor: 2, details: [] });
     setShowCreateModal(false);

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -725,6 +725,21 @@ export const api = {
     });
   },
 
+  getTeamInvitesSent(teamId: number): Promise<{ invite_id: number; sent_at: string; user_id: number }[]> {
+    return fetch(`${API_URL}/teams/${teamId}/invites-sent`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...api.getAuthHeaders(),
+      },
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error('Failed to get team invites sent');
+      }
+      return response.json();
+    });
+  },
+
   // ========== TASKS ==========
   mapBackendTask(task: any): Task {
     return {

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -704,7 +704,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to send team invite');
+          throw new Error(error.error || error.message || 'Failed to send team invite');
         });
       }
     });

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -587,7 +587,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to send join request');
+          throw new Error(error.error || error.message || 'Failed to send join request');
         });
       }
       return response.json();
@@ -604,7 +604,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to get join requests');
+          throw new Error(error.error || error.message || 'Failed to get join requests');
         });
       }
       return response.json();
@@ -621,7 +621,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to accept join request');
+          throw new Error(error.error || error.message || 'Failed to accept join request');
         });
       }
     });
@@ -637,7 +637,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to reject join request');
+          throw new Error(error.error || error.message || 'Failed to reject join request');
         });
       }
     });
@@ -654,7 +654,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to get team invites');
+          throw new Error(error.error || error.message || 'Failed to get team invites');
         });
       }
       return response.json();
@@ -671,7 +671,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to accept team invite');
+          throw new Error(error.error || error.message || 'Failed to accept team invite');
         });
       }
     });
@@ -687,7 +687,7 @@ export const api = {
     }).then((response) => {
       if (!response.ok) {
         return response.json().then((error) => {
-          throw new Error(error.message || 'Failed to reject team invite');
+          throw new Error(error.error || error.message || 'Failed to reject team invite');
         });
       }
     });

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -174,6 +174,21 @@ export const api = {
     });
   },
 
+  checkEmail(email: string): Promise<{ exists: boolean }> {
+    return fetch(`${API_URL}/auth/check-email`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email }),
+    }).then((response) => {
+      if (!response.ok) {
+        return response.json().then((error) => {
+          throw new Error(error.error || 'Failed to check email');
+        });
+      }
+      return response.json();
+    });
+  },
+
   // ========== AVATAR UPLOAD ==========
   uploadAvatar(file: File): Promise<{ avatar_url: string }> {
     const formData = new FormData();

--- a/project/frontend/application/src/services/socket.ts
+++ b/project/frontend/application/src/services/socket.ts
@@ -15,8 +15,7 @@ export function connectSocket(token: string) {
     reconnection: true,
   });
 
-  socket.on('connect_error', (err) => {
-    console.error('Socket connection error:', err.message);
+  socket.on('connect_error', () => {
   });
 }
 

--- a/project/frontend/application/src/utils/errorUtils.ts
+++ b/project/frontend/application/src/utils/errorUtils.ts
@@ -1,0 +1,2 @@
+export function silentLog(..._args: unknown[]) {
+}


### PR DESCRIPTION
Introduction of  a reusable error handling modal to replace console errors / warnings.

- Reusable ErrorModal: Created a generic, reusable error modal component to consistently display error messages to the user.
- Refactored Error Logging: Replaced standard console.error logs with calls to showError(), providing a cleaner user experience instead of silent console failures.
- Modal Depth Fix: Adjusted the z-index properties on modals to ensure they properly stack and overlap other UI elements when triggered.

Errors found:
1. Feed Page (401 Unauthorized): Fixed an issue where unauthenticated users encountered a 404/401 error. Replaced the api.getTeam(team.id) loop in Feed.tsx with a single call to getTeams(), which doesn't require the authMiddleware restriction. ✅

2. Login Page (401 Unauthorized): Resolved a bug where AuthContext.tsx would unconditionally call fetchNotification() even without a session token. Added a quick conditional guard to check for token existence before fetching. ✅

3. Read Notification Loop (404 Not Found): Fixed the backend service for notifications. Removed the restrictive status_read: false query filter from the readNotification method, now safely allowing users to click/read an already read notification without throwing a 404 crash. ✅

4. Duplicate Friend Request Guard: Added a frontend guard in the "Add Friend" by username input. The application now checks the existing friend list locally and prevents a blind, duplicate API request, raising a local error instead. Added corresponding translations for this validation. ✅

I think all errors are covered by the modal or handled silently.
But it would be useful to test the project from now on with the 'console' so that we can catch any remaining ones, if so we can open an issue to handle them. (Any errors found during the PR review can be addressed before continuing ofc).

⚠️ Non-existent Account Login (404 Response): Following team discussion, the backend 404 response when an email is not found during login will remain as-is, Slack subjects were also used as reference. We should be aware in case this is brought up during project defense.

(Sry this comes late guys, I have been overwhelmed).