### PR TITLE
fix: websocket messages with metadata

### DIFF
--- a/project/backend/application/src/message/message.controller.ts
+++ b/project/backend/application/src/message/message.controller.ts
@@ -78,7 +78,7 @@ export const sendMessageController = async (req: AuthRequest, res: Response) => 
 
 	res.status(201).json(request);
 
-	emitWithRetries(getIO(), 'chat message', chatId, content).catch(() => {});
+	emitWithRetries(getIO(), 'chat message', chatId, request).catch(() => {});
 
 };
 

--- a/project/backend/application/src/message/message.service.ts
+++ b/project/backend/application/src/message/message.service.ts
@@ -13,6 +13,8 @@ export const getSentMessages = async (userId: number, friendId: number, amount: 
 		},
 		select: {
 			id: true,
+			sender_id: true,
+			receiver_id: true,
 			content: true,
 			status_read: true,
 			sent_at: true
@@ -27,6 +29,8 @@ export const getSentMessages = async (userId: number, friendId: number, amount: 
 
 	const message_list = messages.map((directMessage) => ({
 		id: directMessage.id,
+		sender_id: directMessage.sender_id,
+		receiver_id: directMessage.receiver_id,
 		content: directMessage.content,
 		status_read: directMessage.status_read,
 		sent_at: directMessage.sent_at,
@@ -48,6 +52,8 @@ export const getReceivedMessages = async (userId: number, friendId: number, amou
 		},
 		select: {
 			id: true,
+			sender_id: true,
+			receiver_id: true,
 			content: true,
 			status_read: true,
 			sent_at: true
@@ -62,6 +68,8 @@ export const getReceivedMessages = async (userId: number, friendId: number, amou
 
 	const message_list = messages.map((directMessage) => ({
 		id: directMessage.id,
+		sender_id: directMessage.sender_id,
+		receiver_id: directMessage.receiver_id,
 		content: directMessage.content,
 		status_read: directMessage.status_read,
 		sent_at: directMessage.sent_at,
@@ -85,6 +93,8 @@ export const getAllMessages = async (userId: number, friendId: number, amount: n
 		},
 		select: {
 			id: true,
+			sender_id: true,
+			receiver_id: true,
 			content: true,
 			status_read: true,
 			sent_at: true
@@ -99,6 +109,8 @@ export const getAllMessages = async (userId: number, friendId: number, amount: n
 
 	const message_list = messages.map((directMessage) => ({
 		id: directMessage.id,
+		sender_id: directMessage.sender_id,
+		receiver_id: directMessage.receiver_id,
 		content: directMessage.content,
 		status_read: directMessage.status_read,
 		sent_at: directMessage.sent_at,
@@ -115,7 +127,7 @@ export const sendMessage = async (userId: number, friendId: number, message: str
 
 	// NOTE: Uncomment this if messages to yourself are not allowed
 	// if (userId === friendId)
-	// 	throw new AppError("Can't send a friend request to yourself.", 400);
+	// 	throw new AppError("Can't send a message to yourself.", 400);
 
 	const receiver = await prisma.user.findUnique({
 		where: {

--- a/project/backend/application/src/teams/team_message.controller.ts
+++ b/project/backend/application/src/teams/team_message.controller.ts
@@ -70,7 +70,7 @@ export const sendTeamMessageController = async (req: AuthRequest, res: Response)
 
 	res.status(201).json(request);
 
-	emitWithRetries(getIO(), 'team message', String(teamId), content).catch(() => {});
+	emitWithRetries(getIO(), 'team message', String(teamId), request).catch(() => {});
 
 };
 

--- a/project/backend/application/src/teams/team_message.service.ts
+++ b/project/backend/application/src/teams/team_message.service.ts
@@ -14,6 +14,7 @@ export const getTeamSentMessages = async (userId: number, teamId: number, amount
 
 		select: {
 			id: true,
+			sender_id: true,
 			content: true,
 			sent_at: true
 		},
@@ -27,6 +28,7 @@ export const getTeamSentMessages = async (userId: number, teamId: number, amount
 
 	const message_list = messages.map((directMessage) => ({
 		id: directMessage.id,
+		sender_id: directMessage.sender_id,
 		content: directMessage.content,
 		sent_at: directMessage.sent_at,
 	}));

--- a/project/backend/application/src/utils/WebSocketUtils.ts
+++ b/project/backend/application/src/utils/WebSocketUtils.ts
@@ -7,7 +7,7 @@ export const emitWithRetries = async (
 	io: Server,
 	event: string,
 	chatId: string,
-	content: string,
+	payload: object,
 	retries = MAX_RETRIES,
 ) => {
 		return new Promise<void>((resolve, reject) => {
@@ -17,7 +17,7 @@ export const emitWithRetries = async (
 			const sendEvent = () => {
 				attempts++;
 
-				io.to(chatId).emit(event, content, (ack: boolean) => {
+				io.to(chatId).emit(event, payload, (ack: boolean) => {
 					if (ack) {
 						console.log(`Acknowledgement received for event: ${event}`);
 						resolve();

--- a/test/rt_chat_test/client.mjs
+++ b/test/rt_chat_test/client.mjs
@@ -193,7 +193,7 @@ async function main() {
 
   // Listeners — each resolves only on the expected cross-delivery marker
   socketA.on('chat message', (msg, ack) => {
-    if (typeof msg === 'string' && msg.includes(markers.b2adm) && !wsRecv.a_dm) {
+    if (typeof msg === 'object' && msg.content.includes(markers.b2adm) && !wsRecv.a_dm) {
       wsRecv.a_dm = true;
       console.log('  A received DM from B');
       if (typeof ack === 'function') ack(true);
@@ -201,7 +201,7 @@ async function main() {
     }
   });
   socketB.on('chat message', (msg, ack) => {
-    if (typeof msg === 'string' && msg.includes(markers.a2bdm) && !wsRecv.b_dm) {
+    if (typeof msg === 'object' && msg.content.includes(markers.a2bdm) && !wsRecv.b_dm) {
       wsRecv.b_dm = true;
       console.log('  B received DM from A');
       if (typeof ack === 'function') ack(true);
@@ -209,7 +209,7 @@ async function main() {
     }
   });
   socketA.on('team message', (msg, ack) => {
-    if (typeof msg === 'string' && msg.includes(markers.b2ateam) && !wsRecv.a_team) {
+    if (typeof msg === 'object' && msg.content.includes(markers.b2ateam) && !wsRecv.a_team) {
       wsRecv.a_team = true;
       console.log('  A received team msg from B');
       if (typeof ack === 'function') ack(true);
@@ -217,7 +217,7 @@ async function main() {
     }
   });
   socketB.on('team message', (msg, ack) => {
-    if (typeof msg === 'string' && msg.includes(markers.a2bteam) && !wsRecv.b_team) {
+    if (typeof msg === 'object' && msg.content.includes(markers.a2bteam) && !wsRecv.b_team) {
       wsRecv.b_team = true;
       console.log('  B received team msg from A');
       if (typeof ack === 'function') ack(true);


### PR DESCRIPTION
# Problem

Only the messages were being sent through the websockets. This caused problems in the frontend to understand who sent the messages and who received them.

# Solution

- The messages sent now have all the metadata of the new message (*id*, *sender_id*, *content* and *status_read*);

# Additional changes

- Added more information that was missing in the GET endpoints