### PR TITLE
Integrated user status in frontend

### DIFF
--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -7,7 +7,7 @@
  * Uses real backend API for authentication and user data.
  */
 
-import { createContext, useState, useEffect, ReactNode } from 'react';
+import { createContext, useState, useEffect, useRef, ReactNode } from 'react';
 import type { AuthContextType, User, Team, Task, Member, Message, Friend, TeamData, FriendRequest, TeamInvite, JoinRequestNotification, AppNotification } from '../types';
 import { api } from '../services/api';
 import { getAvatarUrl } from '../utils/avatar';
@@ -32,6 +32,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [notifications, setNotifications] = useState<AppNotification[]>([]);
   const [unreadCount, setUnreadCount] = useState(0);
   const [teamRefreshTrigger, setTeamRefreshTrigger] = useState(0);
+  const [onlineFriendIds, setOnlineFriendIds] = useState<Set<number>>(new Set());
 
   useEffect(() => {
     const loadUser = async () => {
@@ -75,6 +76,9 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     return () => window.removeEventListener('focus', handleFocus);
   }, []);
 
+  const userRef = useRef(user);
+  userRef.current = user;
+
   useEffect(() => {
     if (user) {
       const token = localStorage.getItem('authToken');
@@ -100,7 +104,8 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             }
             if (n.type === 'team_join_request' || n.type === 'team_join_request_accepted'
                 || n.type === 'team_join_request_rejected') {
-              if (user) fetchJoinRequestNotifications(user.id);
+              const u = userRef.current;
+              if (u) fetchJoinRequestNotifications(u.id);
             }
             if (n.type === 'team_invite_accepted' || n.type === 'team_removed'
                 || n.type === 'team_user_left' || n.type === 'team_join_request_accepted'
@@ -109,13 +114,26 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             }
           };
           sock.on('notification:new', handler);
-          return () => sock.off('notification:new', handler);
+
+          const onlineHandler = (ids: number[]) => setOnlineFriendIds(new Set(ids));
+          const userOnlineHandler = (userId: number) => setOnlineFriendIds((prev) => new Set(prev).add(userId));
+          const userOfflineHandler = (userId: number) => setOnlineFriendIds((prev) => { const next = new Set(prev); next.delete(userId); return next; });
+          sock.on('online friends', onlineHandler);
+          sock.on('user online', userOnlineHandler);
+          sock.on('user offline', userOfflineHandler);
+
+          return () => {
+            sock.off('notification:new', handler);
+            sock.off('online friends', onlineHandler);
+            sock.off('user online', userOnlineHandler);
+            sock.off('user offline', userOfflineHandler);
+          };
         }
       }
     } else {
       disconnectSocket();
     }
-  }, [user]);
+  }, [!!user]);
 
   const logout = () => {
     localStorage.removeItem('authToken');
@@ -450,11 +468,19 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
   };
 
   const fetchFriends = () => {
+    const currentFriendIds = new Set(friends.map(f => f.id));
     api.getFriends().then((friendList) => {
       setFriends(friendList);
       if (user) {
         setUser({ ...user, friends: friendList });
       }
+      friendList.forEach((f: Friend) => {
+        if (!currentFriendIds.has(f.id)) {
+          api.getUserOnline(f.id).then(d => {
+            if (d.Online) setOnlineFriendIds(prev => new Set(prev).add(f.id));
+          }).catch(() => {});
+        }
+      });
     }).catch((err) => {
       console.error('Failed to fetch friends:', err);
     });
@@ -640,6 +666,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
       acceptTeamInvite,
       rejectTeamInvite,
       markNotificationsRead,
+      onlineFriendIds,
     }}>
       {children}
     </AuthContext.Provider>

--- a/project/frontend/application/src/css-styles/06a-profile-pages.css
+++ b/project/frontend/application/src/css-styles/06a-profile-pages.css
@@ -88,6 +88,7 @@
   width: 8px;
   height: 8px;
   border-radius: 50%;
+  display: inline-block;
 }
 
 /*

--- a/project/frontend/application/src/pages/profile/FriendChat.tsx
+++ b/project/frontend/application/src/pages/profile/FriendChat.tsx
@@ -15,7 +15,7 @@ import type { Message } from '../../types';
 function FriendChat() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
-  const { user, sendFriendMessage } = useContext(AuthContext);
+  const { user, sendFriendMessage, onlineFriendIds } = useContext(AuthContext);
   
   const friendId = parseInt(id || '0');
   const friend = user?.friends.find((f) => f.id === friendId);
@@ -73,6 +73,7 @@ function FriendChat() {
         </Link>
         <div className="friend-chat-title">
           <img src={friend.avatar} alt={friend.username} className="friend-chat-avatar" />
+          <span className={`status-indicator ${onlineFriendIds.has(friend.id) ? 'online' : 'offline'}`} />
           <Link to={`/profile/${friend.id}`}><h1>{friend.username}</h1></Link>
         </div>
       </div>

--- a/project/frontend/application/src/pages/profile/Friends.tsx
+++ b/project/frontend/application/src/pages/profile/Friends.tsx
@@ -20,7 +20,7 @@ interface SearchUser {
 
 function Friends() {
   const { t } = useTranslation();
-  const { user, removeFriend, addFriend, friendRequests, sentRequests, friends, acceptFriendRequest, rejectFriendRequest, fetchFriendRequests, fetchSentRequests, fetchFriends } = useContext(AuthContext);
+  const { user, removeFriend, addFriend, friendRequests, sentRequests, friends, acceptFriendRequest, rejectFriendRequest, fetchFriendRequests, fetchSentRequests, fetchFriends, onlineFriendIds } = useContext(AuthContext);
   const [showRemoveModal, setShowRemoveModal] = useState(false);
   const [friendToRemove, setFriendToRemove] = useState<Friend | null>(null);
   const [showAddFriendModal, setShowAddFriendModal] = useState(false);
@@ -149,11 +149,14 @@ function Friends() {
           <div className="friends-list">
             {friends.map((friend) => (
               <div key={friend.id} className="friend-card">
-                <img src={friend.avatar} alt={friend.username} className="friend-avatar" />
+                <div style={{ position: 'relative', display: 'inline-block' }}>
+                  <img src={friend.avatar} alt={friend.username} className="friend-avatar" />
+                  <span className={`status-indicator ${onlineFriendIds.has(friend.id) ? 'online' : 'offline'}`} style={{ position: 'absolute', bottom: 0, right: 0 }} />
+                </div>
                 <div className="friend-info">
                   <Link to={`/profile/${friend.id}`} className="friend-name">{friend.username}</Link>
-                  <span className={`friend-status ${friend.isOnline ? 'online' : 'offline'}`}>
-                    {friend.isOnline ? t('common.online') : t('common.offline')}
+                  <span className={`friend-status ${onlineFriendIds.has(friend.id) ? 'online' : 'offline'}`}>
+                    {onlineFriendIds.has(friend.id) ? t('common.online') : t('common.offline')}
                   </span>
                 </div>
                 <Link

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -28,7 +28,7 @@ function TeamDetail() {
   const { t } = useTranslation();
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { user, leaveTeam, addChatMessage, updateTaskStatus, addTask, uploadFile, deleteTaskFile, updateTaskAssignee, addTeamMember, findUserByUsername, removeTeamMember, updateTeamStatus, updateTeamSettings, fetchNotifications, teamRefreshTrigger } = useContext(AuthContext);
+  const { user, leaveTeam, addChatMessage, updateTaskStatus, addTask, uploadFile, deleteTaskFile, updateTaskAssignee, addTeamMember, findUserByUsername, removeTeamMember, updateTeamStatus, updateTeamSettings, fetchNotifications, teamRefreshTrigger, onlineFriendIds } = useContext(AuthContext);
   const [showLeaveConfirm, setShowLeaveConfirm] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [chatMessage, setChatMessage] = useState('');
@@ -71,6 +71,7 @@ function TeamDetail() {
   const [openAssigneeTask, setOpenAssigneeTask] = useState<number | null>(null);
   const [downloadingFileId, setDownloadingFileId] = useState<number | null>(null);
   const formAssigneeRef = useRef<HTMLDivElement>(null);
+  const [memberOnlineStatus, setMemberOnlineStatus] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
     const fetchTeam = async () => {
@@ -88,6 +89,31 @@ function TeamDetail() {
     };
     fetchTeam();
   }, [id, teamRefreshTrigger]);
+
+  useEffect(() => {
+    if (!team?.members) return;
+    const nonFriendMembers = team.members.filter((m: Member) => m.id !== user?.id && !onlineFriendIds.has(m.id));
+    if (nonFriendMembers.length === 0) return;
+    nonFriendMembers.forEach((m: Member) => {
+      api.getUserOnline(m.id).then(d => {
+        setMemberOnlineStatus(prev => ({ ...prev, [m.id]: d.Online }));
+      }).catch(() => {});
+    });
+  }, [team?.members, user?.id]);
+
+  useEffect(() => {
+    if (!team?.members) return;
+    const poll = setInterval(() => {
+      const toCheck = team.members.filter((m: Member) => m.id !== user?.id && !onlineFriendIds.has(m.id));
+      if (toCheck.length === 0) return;
+      toCheck.forEach((m: Member) => {
+        api.getUserOnline(m.id).then(d => {
+          setMemberOnlineStatus(prev => ({ ...prev, [m.id]: d.Online }));
+        }).catch(() => {});
+      });
+    }, 5000);
+    return () => clearInterval(poll);
+  }, [team?.members, user?.id]);
 
   useEffect(() => {
     const fetchJoinRequests = async () => {
@@ -603,7 +629,10 @@ function TeamDetail() {
         <div className="members-list">
           {team.members.map((member) => (
             <div key={member.id} className="member-card">
-              <img src={member.avatar} alt={member.username} className="member-avatar" />
+              <div style={{ position: 'relative', display: 'inline-block' }}>
+                <img src={member.avatar} alt={member.username} className="member-avatar" />
+                <span className={`status-indicator ${(onlineFriendIds.has(member.id) || memberOnlineStatus[member.id] || member.id === user?.id) ? 'online' : 'offline'}`} style={{ position: 'absolute', bottom: 0, right: 0 }} />
+              </div>
               <Link to={`/profile/${member.id}`} className="member-name">{member.username}</Link>
               <span className={`member-role ${member.role.toLowerCase()}`}>{member.role}</span>
               {isLeader && member.id !== user.id && (

--- a/project/frontend/application/src/pages/profile/UserProfile.tsx
+++ b/project/frontend/application/src/pages/profile/UserProfile.tsx
@@ -10,6 +10,7 @@ function UserProfile() {
   const { userId } = useParams<{ userId: string }>();
   const [profile, setProfile] = useState<UserProfileResponse | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [isOnline, setIsOnline] = useState(false);
 
   const fetchProfile = useCallback(() => {
     if (!userId) return;
@@ -21,6 +22,19 @@ function UserProfile() {
   useEffect(() => {
     fetchProfile();
   }, [fetchProfile]);
+
+  useEffect(() => {
+    if (!userId) return;
+    api.getUserOnline(Number(userId))
+      .then((data) => setIsOnline(data.Online))
+      .catch(() => {});
+    const poll = setInterval(() => {
+      api.getUserOnline(Number(userId))
+        .then((data) => setIsOnline(data.Online))
+        .catch(() => {});
+    }, 5000);
+    return () => clearInterval(poll);
+  }, [userId]);
 
   useEffect(() => {
     const handleVisibility = () => {
@@ -53,6 +67,10 @@ function UserProfile() {
       <div className="profile-header">
         <img src={getAvatarUrl(profile.avatar_url)} alt={profile.username} className="profile-avatar-large" />
         <h1 className="profile-username">{profile.username}</h1>
+        <span className={`status-indicator ${isOnline ? 'online' : 'offline'}`} style={{ marginLeft: '0.5rem' }} />
+        <span className={`friend-status ${isOnline ? 'online' : 'offline'}`} style={{ display: 'inline-flex', marginLeft: '0.25rem' }}>
+          {isOnline ? t('common.online') : t('common.offline')}
+        </span>
         <p className="profile-email">{profile.email}</p>
         {profile.bio && <p className="profile-description">{profile.bio}</p>}
       </div>

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -226,6 +226,22 @@ export const api = {
     });
   },
 
+  // GET /users/:id/online - Returns user online status
+  getUserOnline(userId: number): Promise<{ Online: boolean }> {
+    return fetch(`${API_URL}/users/${userId}/online`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        ...api.getAuthHeaders(),
+      },
+    }).then((response) => {
+      if (!response.ok) {
+        throw new Error('Failed to get user online status');
+      }
+      return response.json();
+    });
+  },
+
   // ========== USER PROFILE ==========
   getCurrentUser(): Promise<UserProfile> {
     return fetch(`${API_URL}/users/me`, {

--- a/project/frontend/application/src/types/index.ts
+++ b/project/frontend/application/src/types/index.ts
@@ -145,6 +145,7 @@ export interface AuthContextType {
   acceptTeamInvite: (inviteId: number) => void;
   rejectTeamInvite: (inviteId: number) => void;
   markNotificationsRead: () => void;
+  onlineFriendIds: Set<number>;
 }
 
 export interface TeamInvite {


### PR DESCRIPTION
This PR integrates user online status indicators across the application (Friends, FriendChat, TeamDetail, and UserProfile).
Friends get real-time online updates via web sockets, while team members and user profiles use a 5-second polling fallback to check status without needing backend changes. (This was the only way found to do it for non friends.)

### AuthContext Optimization:
Introduced onlineFriendIds (Set) state to global context.

Used useRef to track the current user, fixing a bug where notification handlers were using stale user data.

Switched the effect dependency to [!!user] so socket listeners aren't constantly destroyed and recreated whenever the user object updates.

Hooked up listeners for 'online friends', 'user online', and 'user offline'.

### UI Indicators (Friends, FriendChat):
Bound component UI states directly to context state (onlineFriendIds.has(id)).

Wrapped avatars and added visual status indicators.

Non-Friend Fallbacks (UserProfile, TeamDetail):

Because the backend only emits socket updates to an individual's explicit friend circle, a 5-second polling interval was added to track status changes for teammates and non-friend user profiles via the GET /users/:id/online API.

### CSS Fixes:
Added display: inline-block to .status-indicator to resolve an issue where the 8px circle was completely invisible on inline spans.


[NOTE]
If we want to remove the pooling being used in teamDetail ans userProfile the backend must be changed to emit connect/disconnect status events directly into teamDetails. But I don't think this is a big issue.