### PR TITLE
112 frontend  bugs 01

### DIFF
--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -83,6 +83,7 @@
       "language": "Language",
       "username": "Username",
       "email": "Email",
+      "emailNotEditable": " (not editable)",
       "description": "Description",
       "descriptionPlaceholder": "Tell us about yourself...",
       "currentAvatar": "Current Avatar",

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -74,6 +74,7 @@
   },
   "profile": {
     "title": "Profile",
+    "userNotFound": "User not found",
     "collaboration": "Collaboration",
     "teamStats": "Teams Stats",
     "totalTeams": "Total",

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -74,6 +74,7 @@
   },
   "profile": {
     "title": "Profil",
+    "userNotFound": "Utilisateur non trouvé",
     "collaboration": "Collaboration",
     "teamStats": "Statistiques des équipes",
     "totalTeams": "Total",

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -82,6 +82,7 @@
       "title": "Modifier le profil",
       "username": "Nom d'utilisateur",
       "email": "Email",
+      "emailNotEditable": " (non modifiable)",
       "description": "Description",
       "descriptionPlaceholder": "Parlez-nous de vous...",
 "currentAvatar": "Avatar actuel",

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -74,6 +74,7 @@
   },
   "profile": {
     "title": "Perfil",
+    "userNotFound": "Utilizador não encontrado",
     "collaboration": "Colaboração",
     "teamStats": "Estatísticas de Equipas",
     "totalTeams": "Total",

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -82,6 +82,7 @@
       "title": "Editar Perfil",
       "username": "Nome de utilizador",
       "email": "Email",
+      "emailNotEditable": " (não editável)",
       "description": "Descrição",
       "descriptionPlaceholder": "Conte-nos sobre si...",
 "currentAvatar": "Avatar Atual",

--- a/project/frontend/application/src/pages/auth/Register.tsx
+++ b/project/frontend/application/src/pages/auth/Register.tsx
@@ -91,7 +91,7 @@ function Register() {
           />
         </div>
         <div style={{ marginBottom: '1rem' }}>
-          <label className="label" htmlFor="email">{t('auth.register.email')} ({t('common.optional')})</label>
+          <label className="label" htmlFor="email">{t('auth.register.email')}</label>
           <input
             type="email"
             id="email"

--- a/project/frontend/application/src/pages/profile/ProfileEdit.tsx
+++ b/project/frontend/application/src/pages/profile/ProfileEdit.tsx
@@ -22,7 +22,6 @@ function ProfileEdit() {
   const initialAvatar = user?.avatar || '';
 
   const [username, setUsername] = useState(initialUsername);
-  const [email, setEmail] = useState(initialEmail);
   const [description, setDescription] = useState(initialDescription);
   const [avatarUrl, setAvatarUrl] = useState(initialAvatar);
   const [language, setLanguage] = useState((i18n.language || '').split('-')[0] || 'en');
@@ -68,12 +67,10 @@ function ProfileEdit() {
     try {
       const result = await api.updateCurrentUser({
         username,
-        email,
         description,
       });
       updateUser({
         username: result.username,
-        email: result.email,
         description: result.description,
       });
     } catch (err: any) {
@@ -111,13 +108,17 @@ function ProfileEdit() {
         </div>
 
         <div className="form-group">
-          <label className="label">{t('profile.edit.email')}</label>
+          <label className="label">
+            {t('profile.edit.email')}
+            <span style={{ fontSize: '0.85em', color: 'var(--text-secondary)', fontWeight: 'normal', marginLeft: '0.5rem' }}>
+            {t('profile.edit.emailNotEditable')}
+          </span>
+          </label>
           <input
             type="email"
             className="input"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            placeholder={t('auth.login.emailPlaceholder')}
+            value={user?.email || ''}
+            disabled
           />
         </div>
 

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -79,14 +79,24 @@ const { showError } = useError();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const teamIdInt = parseInt(id || '0');
+  const parsedId = parseInt(id || '0');
+  const numericId = isNaN(parsedId) || parsedId <= 0 ? 0 : parsedId;
+  const teamIdInt = numericId;
 
   const fetchTeamData = async (silent = false) => {
     if (!id) return;
+    const numericId = parseInt(id);
+    if (isNaN(numericId) || numericId <= 0) {
+      if (!silent) {
+        setLoadingTeam(false);
+        setTeamError(t('teams.notFound'));
+      }
+      return;
+    }
     try {
       if (!silent) setLoadingTeam(true);
-      const teamData = await api.getTeam(parseInt(id));
-      const messagesData = await api.getTeamMessages(parseInt(id), 50);
+      const teamData = await api.getTeam(numericId);
+      const messagesData = await api.getTeamMessages(numericId, 50);
       
       const formattedMessages: Message[] = messagesData.message_list.map((m: any) => {
         const sender = teamData.members.find((member: any) => member.id === m.sender_id) || 
@@ -104,8 +114,7 @@ const { showError } = useError();
         chat: formattedMessages
       });
     } catch (err) {
-      console.error('Failed to fetch team:', err);
-      if (!silent) setTeamError('Failed to load team');
+      if (!silent) setTeamError(t('teams.notFound'));
     } finally {
       if (!silent) setLoadingTeam(false);
     }
@@ -183,7 +192,7 @@ const { showError } = useError();
     const fetchJoinRequests = async () => {
       if (!id || team?.role !== 'Leader') return;
       try {
-        const data = await api.getJoinRequests(parseInt(id));
+        const data = await api.getJoinRequests(numericId);
         setJoinRequests(data.request_list || []);
       } catch {
       }
@@ -195,7 +204,7 @@ const { showError } = useError();
     const fetchTeamInvitesSent = async () => {
       if (!id || team?.role !== 'Leader') return;
       try {
-        const data = await api.getTeamInvitesSent(parseInt(id));
+        const data = await api.getTeamInvitesSent(numericId);
         setTeamInvitesSent(data || []);
       } catch {
       }
@@ -207,7 +216,7 @@ const { showError } = useError();
     const fetchTasks = async () => {
       if (!id) return;
       try {
-        const taskData = await api.getTasks(parseInt(id));
+        const taskData = await api.getTasks(numericId);
         const tasksWithFiles = await Promise.all(
           taskData.map(async (task) => {
             try {
@@ -414,7 +423,7 @@ const { showError } = useError();
     try {
       await api.acceptJoinRequest(team.id, requestId);
       setJoinRequests(prev => prev.filter(r => r.request_id !== requestId));
-      const updatedTeam = await api.getTeam(parseInt(id));
+      const updatedTeam = await api.getTeam(numericId);
       setTeam(updatedTeam);
       setSuccessMessage(t('teams.joinRequestAccepted'));
       setSuccessReload(false);

--- a/project/frontend/application/src/pages/profile/UserProfile.tsx
+++ b/project/frontend/application/src/pages/profile/UserProfile.tsx
@@ -14,10 +14,17 @@ function UserProfile() {
 
   const fetchProfile = useCallback(() => {
     if (!userId) return;
-    api.getUserProfile(Number(userId))
+    const numericId = Number(userId);
+    if (isNaN(numericId) || numericId <= 0) {
+      setError(t('profile.userNotFound'));
+      return;
+    }
+    api.getUserProfile(numericId)
       .then(setProfile)
-      .catch((err) => setError(err.message));
-  }, [userId]);
+      .catch(() => {
+        setError(t('profile.userNotFound'));
+      });
+  }, [userId, t]);
 
   useEffect(() => {
     fetchProfile();


### PR DESCRIPTION
1. Email:
Profile / Edit : Added 'disabled' attribute and removed 'onChange' handler on Email field. Removed email from the API call since it should not be updated; Removed email state and updates since it is read-only. Added informational text that email is not editable and proper translations.
Register page: Removed extra text that identified email as optional.
✅ FIXED

2. Notification NOT Redirecting to TeamDetail Page:
I could not replicate this issue, Team notifications is properly redirecting to the the team details page if the user is a member of the team. Or else, it correctly falls back into the Teams Overview Page. Maybe during the meeting we were trying to access a team the member was not a member?
⚠️ COULD NOT REPLICATE

3. 'https://localhost/profile/adasdasd' gives errors:
This happened because the text was causing the API to cal the /users/ with NaN. Added a validation that verifies userID before the API calls. Updated the error display and added proper translations. This change was made for both https://localhost/profile/xxx and https://localhost/teams/xxx.
✅ FIXED
⚠️ These still cause console errors, but I think since they are 404, maybe @duartesimo fix for 404 pages will solve them. If not, I'll ad them to #101.