### PR TITLE
104 add notifications to direct messages

### DIFF
--- a/project/backend/application/src/message/message.service.ts
+++ b/project/backend/application/src/message/message.service.ts
@@ -181,7 +181,7 @@ export const sendMessage = async (userId: number, friendId: number, message: str
 	await createNotification(
 		friendId,
 		'direct_message',
-		request.id,
+		friendId,
 		'direct_message',
 		userId,
 		`You got a message from ${sender?.username ?? 'someone'}.`,

--- a/project/backend/application/src/message/message.service.ts
+++ b/project/backend/application/src/message/message.service.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../utils/AppError.js';
 import { prisma } from '../prisma.js';
+import { createNotification } from '../notifications/notifications.service.js';
 
 // Returns messages sent to a friend
 export const getSentMessages = async (userId: number, friendId: number, amount: number) => {
@@ -159,7 +160,7 @@ export const sendMessage = async (userId: number, friendId: number, message: str
 	if (!message)
 		throw new AppError("Message cannot be empty.", 400);
 
-	return prisma.directMessage.create({
+	const request = await prisma.directMessage.create({
 		data: {
 			sender_id: userId,
 			receiver_id: friendId,
@@ -167,6 +168,26 @@ export const sendMessage = async (userId: number, friendId: number, message: str
 			status_read: false,
 		},
 	});
+
+	const sender = await prisma.user.findUnique({
+		where: {
+			id:userId,
+		},
+		select: {
+			username: true,
+		}
+	});
+
+	await createNotification(
+		friendId,
+		'direct_message',
+		request.id,
+		'direct_message',
+		userId,
+		`You got a message from ${sender?.username ?? 'someone'}.`,
+	);
+
+	return request;
 };
 
 // Update read status

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -131,6 +131,28 @@ export const createNotification = async (
 	content?: string,
 
 ) => {
+	const existing = await prisma.notification.findFirst({
+		where: {
+			user_id_receiver: userIdReceiver,
+			user_id_trigger: userIdTrigger,
+			type: type,
+			status_read: false,
+		},
+		orderBy: { created_at: 'desc' },
+	});
+
+	if (existing) {
+		const updated = await prisma.notification.update({
+			where: { id: existing.id, },
+			data: {
+				entity_id: entityId ?? existing.entity_id,
+				created_at: new Date(),
+			},
+		});
+
+		return updated;
+	}
+
 	const notification = await prisma.notification.create({
 		data: {
 			user_id_receiver: userIdReceiver,

--- a/project/backend/application/src/notifications/notifications.service.ts
+++ b/project/backend/application/src/notifications/notifications.service.ts
@@ -150,6 +150,8 @@ export const createNotification = async (
 			},
 		});
 
+		const io = getIO();
+		io.to(`user:${userIdReceiver}`).emit('notification:new', updated);
 		return updated;
 	}
 

--- a/project/backend/application/src/teams/team_message.service.ts
+++ b/project/backend/application/src/teams/team_message.service.ts
@@ -1,6 +1,5 @@
 import { AppError } from '../utils/AppError.js';
 import { prisma } from '../prisma.js';
-import { createNotification } from '../notifications/notifications.service.js';
 
 // Returns messages sent to a team
 export const getTeamSentMessages = async (userId: number, teamId: number, amount: number) => {
@@ -137,42 +136,13 @@ export const sendTeamMessage = async (userId: number, teamId: number, message: s
 	if (!message)
 		throw new AppError("Message cannot be empty.", 400);
 
-	const request = await prisma.teamMessage.create({
+	return prisma.teamMessage.create({
 		data: {
 			sender_id: userId,
 			team_id: teamId,
 			content: message,
 		},
 	});
-
-	const sender = await prisma.user.findUnique({
-		where: {
-			id:userId,
-		},
-		select: {
-			username: true,
-		}
-	});
-
-	const team = await prisma.team.findUnique({
-		where: {
-			id:teamId,
-		},
-		select: {
-			name: true,
-		}
-	});
-
-	await createNotification(
-		teamId,
-		'team_message',
-		request.id,
-		'team_message',
-		userId,
-		`You got a message from ${sender?.username ?? 'someone'} to ${team?.name} team.`,
-	);
-
-	return request;
 };
 
 // Delete team message

--- a/project/backend/application/src/teams/team_message.service.ts
+++ b/project/backend/application/src/teams/team_message.service.ts
@@ -1,5 +1,6 @@
 import { AppError } from '../utils/AppError.js';
 import { prisma } from '../prisma.js';
+import { createNotification } from '../notifications/notifications.service.js';
 
 // Returns messages sent to a team
 export const getTeamSentMessages = async (userId: number, teamId: number, amount: number) => {
@@ -136,13 +137,42 @@ export const sendTeamMessage = async (userId: number, teamId: number, message: s
 	if (!message)
 		throw new AppError("Message cannot be empty.", 400);
 
-	return prisma.teamMessage.create({
+	const request = await prisma.teamMessage.create({
 		data: {
 			sender_id: userId,
 			team_id: teamId,
 			content: message,
 		},
 	});
+
+	const sender = await prisma.user.findUnique({
+		where: {
+			id:userId,
+		},
+		select: {
+			username: true,
+		}
+	});
+
+	const team = await prisma.team.findUnique({
+		where: {
+			id:teamId,
+		},
+		select: {
+			name: true,
+		}
+	});
+
+	await createNotification(
+		teamId,
+		'team_message',
+		request.id,
+		'team_message',
+		userId,
+		`You got a message from ${sender?.username ?? 'someone'} to ${team?.name} team.`,
+	);
+
+	return request;
 };
 
 // Delete team message

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -90,8 +90,15 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
         const sock = getSocket();
         if (sock) {
           const handler = (n: AppNotification) => {
-            setNotifications((prev) => [n, ...prev]);
-            if (!n.status_read) setUnreadCount((c) => c + 1);
+            setNotifications((prev) => {
+				const idx = prev.findIndex(item => item.id === n.id);
+				if (idx >= 0) {
+					return prev.map((item, i) => i === idx ? n : item);
+				}
+
+				if (!n.status_read) setUnreadCount((c) => c + 1);
+				return [n, ...prev];
+			});
 
             if (n.type === 'friend_request' || n.type === 'friend_request_accepted'
                 || n.type === 'friend_request_rejected'

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -94,7 +94,7 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 				const idx = prev.findIndex(item => item.id === n.id);
 				if (idx >= 0) {
 					const copy = [...prev];
-					copy.slice(idx, 1);
+					copy.splice(idx, 1);
 					return [
 						n,
 						...copy.filter(

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -93,7 +93,14 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             setNotifications((prev) => {
 				const idx = prev.findIndex(item => item.id === n.id);
 				if (idx >= 0) {
-					return prev.map((item, i) => i === idx ? n : item);
+					const copy = [...prev];
+					copy.slice(idx, 1);
+					return [
+						n,
+						...copy.filter(
+							item => !(item.type === n.type && item.user_id_trigger === n.user_id_trigger && !item.status_read)
+						),
+					];
 				}
 
 				if (!n.status_read) setUnreadCount((c) => c + 1);

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -119,10 +119,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
             if (n.type === 'direct_message') {
 				fetchFriends();
             }
-			//         NOTE: Uncomment to handle team messages
-				//         if (n.type === 'team_message') {
-				// setTeamRefreshTrigger((c) => c + 1);
-				//         }
           };
           sock.on('notification:new', handler);
 

--- a/project/frontend/application/src/context/AuthContext.tsx
+++ b/project/frontend/application/src/context/AuthContext.tsx
@@ -116,6 +116,13 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
                 || n.type === 'team_join_request') {
               setTeamRefreshTrigger((c) => c + 1);
             }
+            if (n.type === 'direct_message') {
+				fetchFriends();
+            }
+			//         NOTE: Uncomment to handle team messages
+				//         if (n.type === 'team_message') {
+				// setTeamRefreshTrigger((c) => c + 1);
+				//         }
           };
           sock.on('notification:new', handler);
 

--- a/project/frontend/application/src/i18n/locales/en.json
+++ b/project/frontend/application/src/i18n/locales/en.json
@@ -365,6 +365,7 @@
     "teamRemoved": "You were removed from the {{team}} team.",
     "teamUserLeft": "{{username}} left {{team}}.",
     "teamDeleted": "The {{team}} team has been deleted by its owner.",
+    "directMessage": "You got a message from {{username}}.",
     "teamLoadFailed": "Failed to load team information.",
     "subtitle": "Stay up to date with friend requests, team activity, and account updates."
   },

--- a/project/frontend/application/src/i18n/locales/fr.json
+++ b/project/frontend/application/src/i18n/locales/fr.json
@@ -354,6 +354,7 @@
     "teamRemoved": "Vous avez été retiré de l'équipe {{team}}.",
     "teamUserLeft": "{{username}} a quitté {{team}}.",
     "teamDeleted": "L'équipe {{team}} a été supprimée par son propriétaire.",
+    "directMessage": "Vous avez reçu une message de {{username}}.",
     "teamLoadFailed": "Échec du chargement des informations de l'équipe.",
     "subtitle": "Restez informé des demandes d'amitié, de l'activité des équipes et des mises à jour du compte."
   },

--- a/project/frontend/application/src/i18n/locales/pt.json
+++ b/project/frontend/application/src/i18n/locales/pt.json
@@ -355,6 +355,7 @@
     "teamRemoved": "Foi removido da equipa {{team}}.",
     "teamUserLeft": "{{username}} saiu de {{team}}.",
     "teamDeleted": "A equipa {{team}} foi eliminada pelo seu proprietário.",
+    "directMessage": "Você recebeu uma mensagem de {{username}}.",
     "teamLoadFailed": "Falha ao carregar informações da equipa.",
     "subtitle": "Mantém-te a par dos pedidos de amizade, da atividade das equipas e das atualizações da conta."
   },

--- a/project/frontend/application/src/pages/profile/Notifications.tsx
+++ b/project/frontend/application/src/pages/profile/Notifications.tsx
@@ -90,6 +90,17 @@ const NOTIFICATION_PATTERNS: Record<string, { regex: RegExp; vars: string[]; key
     vars: ['team'],
     key: 'teamDeleted',
   },
+  direct_message: {
+    regex: /^You got a message from (.+?)\.$/,
+    vars: ['username'],
+    key: 'directMessage',
+  },
+  // NOTE: Uncomment to add team message notification support
+  // team_message: {
+  //   regex: /^(.+) sent a message in (.+)\.$/,
+  //   vars: ['username', 'team'],
+  //   key: 'teamMessage',
+  // },
 };
 
 function extractTeamName(type: string, content: string | null): string | null {
@@ -125,7 +136,7 @@ function getNotificationText(
 }
 
 function isFriendType(type: string): boolean {
-  return type.startsWith('friend_');
+  return type.startsWith('friend_') || type === 'direct_message';
 }
 
 function isTeamType(type: string): boolean {
@@ -220,34 +231,64 @@ function Notifications() {
         ) : (
           <div className="notifications-list">
             {friendNotifications.map((notification) => (
-              <Link
-                key={notification.id}
-                to="/profile/friends"
-                className={`notification-item${!notification.status_read ? ' unread' : ''}`}
-                onClick={() => markAsRead(notification.id)}
-              >
-                <div className="notification-item-content">
-                  <span className="notification-item-text">
-                    {getNotificationText(notification.type, notification.content, t)}
-                  </span>
+				notification.type === 'direct_message' ? (
+				  <Link
+					key={notification.id}
+					to={`/profile/friends/${notification.user_id_trigger}`}
+					className={`notification-item${!notification.status_read ? ' unread' : ''}`}
+					onClick={() => deleteNotification(notification.id)}
+				  >
+					<div className="notification-item-content">
+					  <span className="notification-item-text">
+						{getNotificationText(notification.type, notification.content, t)}
+					  </span>
 
-                  <span className="notification-item-time">
-                    {getRelativeTime(notification.created_at, t)}
-                  </span>
-                </div>
+					  <span className="notification-item-time">
+						{getRelativeTime(notification.created_at, t)}
+					  </span>
+					</div>
 
-                <button
-                  className="btn btn-danger-actions btn-small"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    deleteNotification(notification.id);
-                  }}
-                >
-                  {t('notifications.delete')}
-                </button>
-              </Link>
-            ))}
+					<button
+					  className="btn btn-danger-actions btn-small"
+					  onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						deleteNotification(notification.id);
+					  }}
+					>
+					  {t('notifications.delete')}
+					</button>
+				  </Link>
+				) : (
+				  <Link
+					key={notification.id}
+					to="/profile/friends"
+					className={`notification-item${!notification.status_read ? ' unread' : ''}`}
+					onClick={() => markAsRead(notification.id)}
+				  >
+					<div className="notification-item-content">
+					  <span className="notification-item-text">
+						{getNotificationText(notification.type, notification.content, t)}
+					  </span>
+
+					  <span className="notification-item-time">
+						{getRelativeTime(notification.created_at, t)}
+					  </span>
+					</div>
+
+					<button
+					  className="btn btn-danger-actions btn-small"
+					  onClick={(e) => {
+						e.preventDefault();
+						e.stopPropagation();
+						deleteNotification(notification.id);
+					  }}
+					>
+					  {t('notifications.delete')}
+					</button>
+				  </Link>
+				)
+			))}
           </div>
         )}
       </div>

--- a/project/frontend/application/src/pages/profile/Notifications.tsx
+++ b/project/frontend/application/src/pages/profile/Notifications.tsx
@@ -95,12 +95,6 @@ const NOTIFICATION_PATTERNS: Record<string, { regex: RegExp; vars: string[]; key
     vars: ['username'],
     key: 'directMessage',
   },
-  // NOTE: Uncomment to add team message notification support
-  // team_message: {
-  //   regex: /^(.+) sent a message in (.+)\.$/,
-  //   vars: ['username', 'team'],
-  //   key: 'teamMessage',
-  // },
 };
 
 function extractTeamName(type: string, content: string | null): string | null {

--- a/project/frontend/application/src/pages/profile/Notifications.tsx
+++ b/project/frontend/application/src/pages/profile/Notifications.tsx
@@ -227,7 +227,7 @@ function Notifications() {
             {friendNotifications.map((notification) => (
 				notification.type === 'direct_message' ? (
 				  <Link
-					key={notification.id}
+					key={`${notification.id}-${notification.created_at}`}
 					to={`/profile/friends/${notification.user_id_trigger}`}
 					className={`notification-item${!notification.status_read ? ' unread' : ''}`}
 					onClick={() => deleteNotification(notification.id)}


### PR DESCRIPTION
## Summary

Full-stack implementation for direct message notifications.

## Features

- Receive a notification when you receive a new direct message;
- Only one notification when the previous one has not been read yet;
- Direct message notifications are deleted on click and go directly to the chat page.

## Possible Problem

Receiving intercalated messages from different friends causes a weird behaviour if you are already on the notifications page.

[Screencast from 2026-06-10 23-28-30.webm](https://github.com/user-attachments/assets/7220bd42-e27d-475c-9abc-db139edf0283)

This happens because I update the notification creation time, and the page refreshes.

If I remove the update, the notifications will be unordered.

**What do you think is the best behaviour?**

