### PR TITLE
111 fronted   oauth

### DIFF
--- a/project/frontend/application/package-lock.json
+++ b/project/frontend/application/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ttm-frontend",
       "version": "1.0.0",
       "dependencies": {
+        "@react-oauth/google": "^0.12.1",
         "i18next": "^26.0.10",
         "i18next-browser-languagedetector": "^8.2.1",
         "react": "^18.2.0",
@@ -807,6 +808,16 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@react-oauth/google": {
+      "version": "0.12.2",
+      "resolved": "https://registry.npmjs.org/@react-oauth/google/-/google-0.12.2.tgz",
+      "integrity": "sha512-d1GVm2uD4E44EJft2RbKtp8Z1fp/gK8Lb6KHgs3pHlM0PxCXGLaq8LLYQYENnN4xPWO1gkL4apBtlPKzpLvZwg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
       }
     },
     "node_modules/@remix-run/router": {

--- a/project/frontend/application/package.json
+++ b/project/frontend/application/package.json
@@ -9,6 +9,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@react-oauth/google": "^0.12.1",
     "i18next": "^26.0.10",
     "i18next-browser-languagedetector": "^8.2.1",
     "react": "^18.2.0",

--- a/project/frontend/application/src/css-styles/04-auth.css
+++ b/project/frontend/application/src/css-styles/04-auth.css
@@ -244,9 +244,8 @@
 }
 
 .auth-social-buttons {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.85rem;
+  display: flex;
+  justify-content: center;
 }
 
 .auth-social-btn {

--- a/project/frontend/application/src/main.tsx
+++ b/project/frontend/application/src/main.tsx
@@ -15,6 +15,7 @@
  */
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { GoogleOAuthProvider } from '@react-oauth/google'
 import App from './App'
 import './i18n'
 import './css-styles/index.css'
@@ -28,6 +29,8 @@ import './css-styles/index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <GoogleOAuthProvider clientId={import.meta.env.VITE_GOOGLE_CLIENT_ID}>
+      <App />
+    </GoogleOAuthProvider>
   </React.StrictMode>,
 )

--- a/project/frontend/application/src/pages/auth/Login.tsx
+++ b/project/frontend/application/src/pages/auth/Login.tsx
@@ -203,8 +203,13 @@ const result = await api.verify2FA(tempToken, twoFactorCode);
               onSuccess={async (credentialResponse) => {
                 try {
                   const result = await api.googleLogin(credentialResponse.credential);
-                  localStorage.setItem('authToken', result.token);
-                  window.location.href = '/';
+                  if (result.requires_2fa && result.temp_token) {
+                    setTempToken(result.temp_token);
+                    setShow2FA(true);
+                  } else {
+                    localStorage.setItem('authToken', result.token);
+                    window.location.href = '/';
+                  }
                 } catch (err: any) {
                   setError(err.message || 'Google login failed');
                 }

--- a/project/frontend/application/src/pages/auth/Login.tsx
+++ b/project/frontend/application/src/pages/auth/Login.tsx
@@ -15,6 +15,7 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { GoogleLogin } from '@react-oauth/google';
 import AuthLayout from '../../components/layouts/AuthLayout';
 import { api } from '../../services/api';
 
@@ -196,16 +197,22 @@ const result = await api.verify2FA(tempToken, twoFactorCode);
             <span>or continue with</span>
           </div>
 
-          <div className="auth-social-buttons">
-            <button type="button" className="auth-social-btn">
-              <img src="/42logo.png" alt="42 logo" />
-              <span>42 School</span>
-            </button>
-
-            <button type="button" className="auth-social-btn">
-              <img src="/google-logo.webp" alt="Google logo" />
-              <span>Google</span>
-            </button>
+          <div className="auth-social-buttons" style={{ display: 'flex', justifyContent: 'center' }}>
+            <GoogleLogin
+              locale="en"
+              onSuccess={async (credentialResponse) => {
+                try {
+                  const result = await api.googleLogin(credentialResponse.credential);
+                  localStorage.setItem('authToken', result.token);
+                  window.location.href = '/';
+                } catch (err: any) {
+                  setError(err.message || 'Google login failed');
+                }
+              }}
+              onError={() => {
+                setError('Google login failed. Please try again.');
+              }}
+            />
           </div>
           <p className="auth-terms-note">
             By signing in, you agree with our <br />

--- a/project/frontend/application/src/services/api.ts
+++ b/project/frontend/application/src/services/api.ts
@@ -204,6 +204,21 @@ export const api = {
     });
   },
 
+  googleLogin(credential: string): Promise<AuthResponse> {
+    return fetch(`${API_URL}/auth/google`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ credential }),
+    }).then((response) => {
+      if (!response.ok) {
+        return response.json().then((error) => {
+          throw new Error(error.error || 'Google login failed');
+        });
+      }
+      return response.json();
+    });
+  },
+
   // ========== AVATAR UPLOAD ==========
   uploadAvatar(file: File): Promise<{ avatar_url: string }> {
     const formData = new FormData();


### PR DESCRIPTION
### Implementation of Google OAuth authentication in the Frontend.
Integration with the existing authentication system, including support for 2FA.

Changes:
- Added @react-oauth/google package
- Integrated Google OAuth Provider in main.tsx
- Removed "Sign in with 42" button to Login page
- Implemented OAuth flow without and with 2FA support
- Added googleLogin() API method

**Note:** To test this you need to have the .env with the codes provided by @diogo-adao.