### PR TITLE
Added email verification

### DIFF
--- a/project/backend/application/src/auth/auth.controller.ts
+++ b/project/backend/application/src/auth/auth.controller.ts
@@ -1,22 +1,29 @@
 import type { Request, Response } from 'express';
-import { register, login, verify2FA, checkEmail, googleLogin } from './auth.service.js';
+import { register, login, verify2FA, checkEmail, googleLogin, verifyEmail } from './auth.service.js';
 
- export const registerUser = async (req: Request, res: Response) => {
-   const result = await register(req.body);
-   res.status(201).json(result);
- };
+export const registerUser = async (req: Request, res: Response) => {
+  const result = await register(req.body);
+  res.status(201).json(result);
+};
 
- export const loginUser = async (req: Request, res: Response) => {
-   const result = await login(req.body);
-   res.json(result);
- };
+export const loginUser = async (req: Request, res: Response) => {
+  const result = await login(req.body);
+  res.json(result);
+};
 
- export const verify2FAController = async (req: Request, res: Response) => {
-   const { temp_token, code } = req.body;
+export const verify2FAController = async (req: Request, res: Response) => {
+  const { temp_token, code } = req.body;
 
   const result = await verify2FA(temp_token, code);
   res.json(result);
 };
+
+export const verifyEmailController = async (req: Request, res: Response) => {
+  const { temp_token, code } = req.body;
+
+  const result = await verifyEmail(temp_token, code);
+  res.json(result);
+}
 
 export const checkEmailController = async (req: Request, res: Response) => {
   const { email } = req.body;

--- a/project/backend/application/src/auth/auth.routes.ts
+++ b/project/backend/application/src/auth/auth.routes.ts
@@ -1,5 +1,5 @@
 import express from 'express';
-import { registerUser, loginUser, verify2FAController, checkEmailController, googleLoginController } from './auth.controller.js';
+import { registerUser, loginUser, verify2FAController, checkEmailController, googleLoginController, verifyEmailController } from './auth.controller.js';
 import { asyncHandler } from '../utils/AppError.js';
 
 const router = express.Router();
@@ -7,6 +7,7 @@ const router = express.Router();
 router.post('/register', asyncHandler(registerUser));
 router.post('/login', asyncHandler(loginUser));
 router.post('/verify-2fa', asyncHandler(verify2FAController));
+router.post('/verify-email', asyncHandler(verifyEmailController));
 router.post('/check-email', asyncHandler(checkEmailController));
 router.post("/google", asyncHandler(googleLoginController));
 

--- a/project/backend/application/src/auth/auth.service.ts
+++ b/project/backend/application/src/auth/auth.service.ts
@@ -6,6 +6,8 @@ import { AppError } from '../utils/AppError.js';
 import type { RegisterDTO, LoginDTO } from './auth.types.js';
 import { OAuth2Client } from "google-auth-library";
 import { handle2FA } from '../utils/2fa.js';
+import { pendingRegistrations, pending2FA } from '../utils/storage.js';
+import { sendVerificationCode } from '../utils/mailer.js';
 
 const client = new OAuth2Client(GOOGLE_CLIENT_ID);
 
@@ -15,8 +17,6 @@ export const register = async (data: RegisterDTO) => {
   if (!email || !username || !password) {
     throw new AppError('Missing required fields', 400);
   }
-
-  const hashedPassword = await bcrypt.hash(password, 10);
 
   const existingEmail = await prisma.user.findUnique({
     where: { email },
@@ -34,18 +34,88 @@ export const register = async (data: RegisterDTO) => {
     throw new AppError('Username already exists', 400);
   }
 
+  const hashedPassword = await bcrypt.hash(password, 10);
+
+  const code = Math.floor(100000 + Math.random() * 900000).toString();
+
+  pendingRegistrations.set(email, {
+    email,
+    username,
+    hashedPassword,
+    code,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  });
+
+  await sendVerificationCode(email, code);
+
+  const tempToken = jwt.sign(
+    {
+      email,
+      type: "email_verification",
+    },
+    JWT_SECRET,
+    { expiresIn: "5m" }
+  );
+
+  return {
+    requires_verification: true,
+    temp_token: tempToken,
+  };
+}
+
+export const verifyEmail = async (tempToken: string, code: string) => {
+  if (!tempToken || !code) {
+    throw new AppError("Missing required fields", 400);
+  }
+  
+  let payload: any;
+
+  try {
+    payload = jwt.verify(tempToken, JWT_SECRET);
+  } catch {
+    throw new AppError("Invalid or expired token", 400);
+  }
+
+  if (payload.type !== "email_verification") {
+    throw new AppError("Invalid token", 400);
+  }
+
+  const pending = pendingRegistrations.get(payload.email);
+
+  if (!pending) {
+    throw new AppError("Verification expired", 400);
+  }
+
+  if (pending.code !== code) {
+    throw new AppError("Invalid code", 400);
+  }
+
+  const existingUsername = await prisma.user.findUnique({
+    where: { username: pending.username },
+  });
+
+  if (existingUsername) {
+    throw new AppError("Username already exists", 400);
+  }
+
   const user = await prisma.user.create({
     data: {
-      email,
-      username,
-      password_hash: hashedPassword,
+      email: pending.email,
+      username: pending.username,
+      password_hash: pending.hashedPassword,
     },
   });
 
-  const token = jwt.sign({ id: user.id, type: "auth" }, JWT_SECRET);
+  pendingRegistrations.delete(payload.email);
+
+  const token = jwt.sign({id: user.id, type: "auth" }, JWT_SECRET);
 
   return {
-    user: { id: user.id, email: user.email, username: user.username },
+    user: {
+      id: user.id,
+      email: user.email,
+      username: user.username,
+    },
     token,
   };
 };
@@ -108,7 +178,17 @@ export const verify2FA = async (tempToken: string, code: string) => {
     throw new AppError("Invalid or expired token", 400);
   }
 
-  if (payload.twoFactorCode !== code) {
+  if (payload.type !== "2fa") {
+    throw new AppError("Invalid token", 400);
+  }
+
+  const pending = pending2FA.get(payload.userId);
+
+  if (!pending) {
+    throw new AppError("2FA expired", 400);
+  }
+
+  if (pending.code !== code) {
     throw new AppError("Invalid code", 400);
   }
 
@@ -119,6 +199,8 @@ export const verify2FA = async (tempToken: string, code: string) => {
   if (!user) {
     throw new AppError("User not found", 404);
   }
+
+  pending2FA.delete(payload.userId);
 
   const token = jwt.sign({ id: user.id, type: "auth" }, JWT_SECRET);
 

--- a/project/backend/application/src/users/users.controller.ts
+++ b/project/backend/application/src/users/users.controller.ts
@@ -9,8 +9,8 @@ export const getMeController = async (req: AuthRequest, res: Response) => {
 };
 
 export const updateMeController = async (req: AuthRequest, res: Response) => {
-  const { username, email, bio } = req.body;
-  const data: UpdateUserDTO = { username, email, bio };
+  const { username, bio } = req.body;
+  const data: UpdateUserDTO = { username, bio };
 
   if (req.file) {
     data.avatar_url = `/api/uploads/avatars/${req.file.filename}`;

--- a/project/backend/application/src/users/users.service.ts
+++ b/project/backend/application/src/users/users.service.ts
@@ -25,20 +25,7 @@ export const getMe = async (userId: number) => {
 };
 
 export const updateMe = async (userId: number, data: UpdateUserDTO) => {
-  const { email, username } = data;
-
-  if (email) {
-    const existingEmail = await prisma.user.findFirst({
-      where: {
-        email,
-        NOT: { id: userId },
-      },
-    });
-
-    if (existingEmail) {
-      throw new AppError('Email already in use', 400);
-    }
-  }
+  const { username } = data;
 
   if (username) {
     const existingUsername = await prisma.user.findFirst({

--- a/project/backend/application/src/users/users.types.ts
+++ b/project/backend/application/src/users/users.types.ts
@@ -1,6 +1,5 @@
 export type UpdateUserDTO = {
   username?: string;
-  email?: string;
   bio?: string;
   avatar_url?: string;
 };

--- a/project/backend/application/src/utils/2fa.ts
+++ b/project/backend/application/src/utils/2fa.ts
@@ -2,16 +2,22 @@ import jwt from "jsonwebtoken";
 import { JWT_SECRET } from "../config.js";
 import { send2FACode } from "./mailer.js";
 import type { User } from "@prisma/client";
+import { pending2FA } from "./storage.js";
 
 export const handle2FA = async (user: User) => {
   const code = Math.floor(100000 + Math.random() * 900000).toString();
 
   await send2FACode(user.email, code);
 
+  pending2FA.set(user.id, {
+    userId: user.id,
+    code,
+    expiresAt: Date.now() + 5 * 60 * 1000,
+  });
+
   const tempToken = jwt.sign(
     {
       userId: user.id,
-      twoFactorCode: code,
       type: "2fa",
     },
     JWT_SECRET,

--- a/project/backend/application/src/utils/mailer.ts
+++ b/project/backend/application/src/utils/mailer.ts
@@ -21,3 +21,16 @@ export const send2FACode = async (email: string, code: string) => {
     `,
   });
 };
+
+export const sendVerificationCode = async (email: string, code: string) => {
+  await transporter.sendMail({
+    from: `"Transcendence" <${SMTP_EMAIL}>`,
+    to: email,
+    subject: "Your Registration Code",
+    html: `
+      <h3>Your registration code is:</h3>
+      <h1>${code}</h1>
+      <p><em>This code expires in 5 minutes.</em></p>
+    `,
+  });
+}

--- a/project/backend/application/src/utils/storage.ts
+++ b/project/backend/application/src/utils/storage.ts
@@ -1,0 +1,32 @@
+type PendingRegistration = {
+  email: string;
+  username: string;
+  hashedPassword: string;
+  code: string;
+  expiresAt: number;
+};
+
+type Pending2FA = {
+  userId: number;
+  code: string;
+  expiresAt: number;
+};
+
+export const pendingRegistrations = new Map<string, PendingRegistration>();
+export const pending2FA = new Map<number, Pending2FA>();
+
+setInterval(() => {
+  const now = Date.now();
+
+  for (const [email, data] of pendingRegistrations.entries()) {
+    if (data.expiresAt < now) {
+      pendingRegistrations.delete(email);
+    }
+  }
+
+  for (const [userId, data] of pending2FA.entries()) {
+    if (data.expiresAt < now) {
+      pending2FA.delete(userId);
+    }
+  }
+}, 60_000);


### PR DESCRIPTION
# Email Verification

Besides the email verification feature, this PR also includes some fixes and improvements in the backend.

## New endpoint: `POST /auth/verify-email`
At registration, users will now be requested to enter a code sent to their emails. This will prevent **fake emails, identity theft and losing access to the account**. This endpoint follows the same logic as `POST /auth/verify-2fa`.

## Fixes and Improvements
- To complete the protection of verifying email at registration, I also removed `email` from `PUT /users/me` so it can't be changed afterwards.
- During development I noticed a security issue with temporary tokens. Verification codes were being stored in the token itself, making the verification useless if an attacker decoded the token. For this and as we agreed, I created an in-memory storage that includes codes and other sensitive information that should never be sent to frontend. 
The data saved in that storage is checked every minute and it gets deleted if the code expires and also deleted after a successful request.