### PR TITLE
Frontend profile teams xxx

### DIFF
--- a/project/frontend/application/src/App.tsx
+++ b/project/frontend/application/src/App.tsx
@@ -157,6 +157,7 @@ function App() {
               </ProtectedRoute>
             }
           />
+          <Route path="/404" element={<NotFound />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Router>

--- a/project/frontend/application/src/pages/profile/FriendChat.tsx
+++ b/project/frontend/application/src/pages/profile/FriendChat.tsx
@@ -143,6 +143,10 @@ function FriendChat() {
     return <Navigate to="/404" replace />;
   }
 
+  if (user && friendId === user.id) {
+    return <Navigate to="/profile/friends" replace />;
+  }
+
   const displayFriend = friend ?? friendInfo!;
   const chat = friend?.chat || [];
 

--- a/project/frontend/application/src/pages/profile/FriendChat.tsx
+++ b/project/frontend/application/src/pages/profile/FriendChat.tsx
@@ -19,7 +19,8 @@ function FriendChat() {
   const { id } = useParams<{ id: string }>();
   const { user, sendFriendMessage, updateUser, onlineFriendIds } = useContext(AuthContext);
 
-  const friendId = Number(id || '0');
+  const idString = id || '';
+  const friendId = /^\d+$/.test(idString) ? Number(idString) : NaN;
   const friend = user?.friends.find((f) => f.id === friendId);
   const [friendInfo, setFriendInfo] = useState<{ id: number; username: string; avatar: string } | null>(null);
   const [isLoadingFriend, setIsLoadingFriend] = useState(true);
@@ -130,6 +131,10 @@ function FriendChat() {
       messagesEndRef.current.scrollIntoView({ behavior: 'smooth' });
     }
   }, [friend?.chat]);
+
+  if (!friendId || isNaN(friendId) || !Number.isInteger(friendId)) {
+    return <Navigate to="/profile/friends" replace />;
+  }
 
   if (isLoadingFriend) {
     return (

--- a/project/frontend/application/src/pages/profile/FriendChat.tsx
+++ b/project/frontend/application/src/pages/profile/FriendChat.tsx
@@ -5,7 +5,7 @@
  */
 
 import { useContext, useState, useRef, useEffect } from 'react';
-import { useParams, Link } from 'react-router-dom';
+import { useParams, Link, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
 import { api } from '../../services/api';
@@ -29,7 +29,7 @@ function FriendChat() {
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (!user || !friendId) return;
+    if (!user || !friendId || isNaN(friendId)) return;
 
     const socket = getSocket();
     if (socket) {
@@ -54,7 +54,7 @@ function FriendChat() {
   }, [user?.id, friendId]);
 
   useEffect(() => {
-    if (!friend && !friendInfo && !friendError) {
+    if (!friend && !friendInfo && !friendError && friendId && !isNaN(friendId)) {
       api.getUserProfile(friendId)
         .then(data => {
           setFriendInfo({
@@ -140,13 +140,7 @@ function FriendChat() {
   }
 
   if (friendError || (!friend && !friendInfo)) {
-    return (
-      <div className="friend-chat-page">
-        <h1>{t('friends.notFound') || 'Friend not found'}</h1>
-        <p>{t('friends.notFoundDesc') || 'This friend does not exist or you are not friends.'}</p>
-        <Link to="/profile/friends" className="btn btn-secondary">{t('friends.backToFriends') || 'Back to Friends'}</Link>
-      </div>
-    );
+    return <Navigate to="/404" replace />;
   }
 
   const displayFriend = friend ?? friendInfo!;

--- a/project/frontend/application/src/pages/profile/FriendChat.tsx
+++ b/project/frontend/application/src/pages/profile/FriendChat.tsx
@@ -19,7 +19,7 @@ function FriendChat() {
   const { id } = useParams<{ id: string }>();
   const { user, sendFriendMessage, updateUser, onlineFriendIds } = useContext(AuthContext);
 
-  const friendId = parseInt(id || '0');
+  const friendId = Number(id || '0');
   const friend = user?.friends.find((f) => f.id === friendId);
   const [friendInfo, setFriendInfo] = useState<{ id: number; username: string; avatar: string } | null>(null);
   const [isLoadingFriend, setIsLoadingFriend] = useState(true);

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -75,7 +75,9 @@ const { showError } = useError();
   const [showFormAssigneeDropdown, setShowFormAssigneeDropdown] = useState(false);
   const [openAssigneeTask, setOpenAssigneeTask] = useState<number | null>(null);
   const [downloadingFileId, setDownloadingFileId] = useState<number | null>(null);
+  const [uploadingFileId, setUploadingFileId] = useState<number | null>(null);
   const formAssigneeRef = useRef<HTMLDivElement>(null);
+  const [userTeamIds, setUserTeamIds] = useState<number[]>([]);
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -83,10 +85,17 @@ const { showError } = useError();
   const numericId = isNaN(parsedId) || parsedId <= 0 || !Number.isSafeInteger(parsedId) ? 0 : parsedId;
   const teamIdInt = numericId;
 
-  const fetchTeamData = async (silent = false) => {
+  const fetchTeamData = async (silent = false, teamIds: number[] = []) => {
     if (!id) return;
     const numericId = Number(id);
     if (isNaN(numericId) || numericId <= 0 || !Number.isSafeInteger(numericId)) {
+      if (!silent) {
+        setLoadingTeam(false);
+        setTeamError(t('teams.notFound'));
+      }
+      return;
+    }
+    if (teamIds.length === 0 || !teamIds.includes(numericId)) {
       if (!silent) {
         setLoadingTeam(false);
         setTeamError(t('teams.notFound'));
@@ -123,14 +132,34 @@ const { showError } = useError();
   const [memberOnlineStatus, setMemberOnlineStatus] = useState<Record<number, boolean>>({});
 
   useEffect(() => {
-    fetchTeamData();
+    api.getMyTeams().then((teams) => {
+      const ids = teams.map((t: any) => t.id);
+      setUserTeamIds(ids);
+      if (ids.includes(numericId)) {
+        fetchTeamData(false, ids);
+      } else {
+        setLoadingTeam(false);
+        setTeamError(t('teams.notFound'));
+      }
+    }).catch(() => {
+      setLoadingTeam(false);
+      setTeamError(t('teams.notFound'));
+    });
   }, [id]);
 
   useEffect(() => {
-    if (team) {
-      fetchTeamData(true);
-    }
+    if (teamRefreshTrigger === 0) return;
+    api.getMyTeams().then((teams) => {
+      const ids = teams.map((t: any) => t.id);
+      setUserTeamIds(ids);
+    }).catch(() => {});
   }, [teamRefreshTrigger]);
+
+  useEffect(() => {
+    if (team && userTeamIds.length > 0) {
+      fetchTeamData(true, userTeamIds);
+    }
+  }, [teamRefreshTrigger, userTeamIds]);
 
   useEffect(() => {
     if (!teamIdInt || teamError) return;
@@ -143,7 +172,7 @@ const { showError } = useError();
 
       const handleNewTeamMessage = (content: string, ack?: (ok: boolean) => void) => {
         if (ack) ack(true);
-        fetchTeamData(true);
+        fetchTeamData(true, userTeamIds);
       };
 
       socket.on('team message', handleNewTeamMessage);
@@ -153,9 +182,9 @@ const { showError } = useError();
           console.log('Left team chat:', res);
         });
         socket.off('team message', handleNewTeamMessage);
-      };
+      }
     }
-  }, [teamIdInt, teamError]);
+  }, [teamIdInt, teamError, userTeamIds]);
 
   useEffect(() => {
     if (messagesEndRef.current) {
@@ -215,6 +244,7 @@ const { showError } = useError();
   useEffect(() => {
     const fetchTasks = async () => {
       if (!id || !numericId || teamError) return;
+      if (userTeamIds.length === 0 || !userTeamIds.includes(numericId)) return;
       try {
         const taskData = await api.getTasks(numericId);
         const tasksWithFiles = await Promise.all(
@@ -232,7 +262,7 @@ const { showError } = useError();
       }
     };
     fetchTasks();
-  }, [id, teamRefreshTrigger, teamError]);
+  }, [id, teamRefreshTrigger, teamError, userTeamIds]);
 
   useEffect(() => {
     if (showAddMemberModal) {

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -11,7 +11,7 @@
  */
 
 import { useContext, useState, useEffect, useRef } from 'react';
-import { useParams, useNavigate, Link } from 'react-router-dom';
+import { useParams, useNavigate, Link, Navigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { AuthContext } from '../../context/AuthContext';
 import { useError } from '../../context/ErrorContext';
@@ -133,7 +133,7 @@ const { showError } = useError();
   }, [teamRefreshTrigger]);
 
   useEffect(() => {
-    if (!teamIdInt) return;
+    if (!teamIdInt || teamError) return;
 
     const socket = getSocket();
     if (socket) {
@@ -155,7 +155,7 @@ const { showError } = useError();
         socket.off('team message', handleNewTeamMessage);
       };
     }
-  }, [teamIdInt]);
+  }, [teamIdInt, teamError]);
 
   useEffect(() => {
     if (messagesEndRef.current) {
@@ -190,7 +190,7 @@ const { showError } = useError();
 
   useEffect(() => {
     const fetchJoinRequests = async () => {
-      if (!id || team?.role !== 'Leader') return;
+      if (!id || !numericId || team?.role !== 'Leader') return;
       try {
         const data = await api.getJoinRequests(numericId);
         setJoinRequests(data.request_list || []);
@@ -202,7 +202,7 @@ const { showError } = useError();
 
   useEffect(() => {
     const fetchTeamInvitesSent = async () => {
-      if (!id || team?.role !== 'Leader') return;
+      if (!id || !numericId || team?.role !== 'Leader') return;
       try {
         const data = await api.getTeamInvitesSent(numericId);
         setTeamInvitesSent(data || []);
@@ -214,7 +214,7 @@ const { showError } = useError();
 
   useEffect(() => {
     const fetchTasks = async () => {
-      if (!id) return;
+      if (!id || !numericId) return;
       try {
         const taskData = await api.getTasks(numericId);
         const tasksWithFiles = await Promise.all(
@@ -302,12 +302,7 @@ const { showError } = useError();
   }
 
   if (teamError || !team) {
-    return (
-      <div className="team-detail-page">
-        <h1>{t('teams.notFound') || 'Team not found'}</h1>
-        <p>{t('teams.notFoundDesc') || 'This team does not exist or you are not a member.'}</p>
-      </div>
-    );
+    return <Navigate to="/404" replace />;
   }
 
   const availableUsers = allUsers

--- a/project/frontend/application/src/pages/profile/TeamDetail.tsx
+++ b/project/frontend/application/src/pages/profile/TeamDetail.tsx
@@ -79,14 +79,14 @@ const { showError } = useError();
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
-  const parsedId = parseInt(id || '0');
-  const numericId = isNaN(parsedId) || parsedId <= 0 ? 0 : parsedId;
+  const parsedId = Number(id || '0');
+  const numericId = isNaN(parsedId) || parsedId <= 0 || !Number.isSafeInteger(parsedId) ? 0 : parsedId;
   const teamIdInt = numericId;
 
   const fetchTeamData = async (silent = false) => {
     if (!id) return;
-    const numericId = parseInt(id);
-    if (isNaN(numericId) || numericId <= 0) {
+    const numericId = Number(id);
+    if (isNaN(numericId) || numericId <= 0 || !Number.isSafeInteger(numericId)) {
       if (!silent) {
         setLoadingTeam(false);
         setTeamError(t('teams.notFound'));
@@ -190,7 +190,7 @@ const { showError } = useError();
 
   useEffect(() => {
     const fetchJoinRequests = async () => {
-      if (!id || !numericId || team?.role !== 'Leader') return;
+      if (!id || !numericId || team?.role !== 'Leader' || teamError) return;
       try {
         const data = await api.getJoinRequests(numericId);
         setJoinRequests(data.request_list || []);
@@ -198,11 +198,11 @@ const { showError } = useError();
       }
     };
     fetchJoinRequests();
-  }, [id, team?.role, teamRefreshTrigger]);
+  }, [id, team?.role, teamRefreshTrigger, teamError]);
 
   useEffect(() => {
     const fetchTeamInvitesSent = async () => {
-      if (!id || !numericId || team?.role !== 'Leader') return;
+      if (!id || !numericId || team?.role !== 'Leader' || teamError) return;
       try {
         const data = await api.getTeamInvitesSent(numericId);
         setTeamInvitesSent(data || []);
@@ -210,11 +210,11 @@ const { showError } = useError();
       }
     };
     fetchTeamInvitesSent();
-  }, [id, team?.role, teamRefreshTrigger, showAddMemberModal]);
+  }, [id, team?.role, teamRefreshTrigger, showAddMemberModal, teamError]);
 
   useEffect(() => {
     const fetchTasks = async () => {
-      if (!id || !numericId) return;
+      if (!id || !numericId || teamError) return;
       try {
         const taskData = await api.getTasks(numericId);
         const tasksWithFiles = await Promise.all(
@@ -232,7 +232,7 @@ const { showError } = useError();
       }
     };
     fetchTasks();
-  }, [id, teamRefreshTrigger]);
+  }, [id, teamRefreshTrigger, teamError]);
 
   useEffect(() => {
     if (showAddMemberModal) {

--- a/project/frontend/application/src/pages/profile/UserProfile.tsx
+++ b/project/frontend/application/src/pages/profile/UserProfile.tsx
@@ -15,7 +15,7 @@ function UserProfile() {
   const fetchProfile = useCallback(() => {
     if (!userId) return;
     const numericId = Number(userId);
-    if (isNaN(numericId) || numericId <= 0) {
+    if (isNaN(numericId) || numericId <= 0 || !Number.isSafeInteger(numericId)) {
       setError(t('profile.userNotFound'));
       return;
     }

--- a/project/frontend/application/src/pages/profile/UserProfile.tsx
+++ b/project/frontend/application/src/pages/profile/UserProfile.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams } from 'react-router-dom';
+import { useParams, Navigate } from 'react-router-dom';
 import { api } from '../../services/api';
 import type { UserProfileResponse } from '../../services/api';
 import { getAvatarUrl } from '../../utils/avatar';
@@ -31,7 +31,7 @@ function UserProfile() {
   }, [fetchProfile]);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!userId || error) return;
     api.getUserOnline(Number(userId))
       .then((data) => setIsOnline(data.Online))
       .catch(() => { });
@@ -41,7 +41,7 @@ function UserProfile() {
         .catch(() => { });
     }, 5000);
     return () => clearInterval(poll);
-  }, [userId]);
+  }, [userId, error]);
 
   useEffect(() => {
     const handleVisibility = () => {
@@ -54,11 +54,7 @@ function UserProfile() {
   }, [fetchProfile]);
 
   if (error) {
-    return (
-      <div className="profile-page">
-        <p className="error-message">{error}</p>
-      </div>
-    );
+    return <Navigate to="/404" replace />;
   }
 
   if (!profile) {


### PR DESCRIPTION
### Frontend URL Parameter Validation Guards
**This PR aims to solve point 2 of #101** 

Added URL parameter validation guards to prevent navigation to invalid or malformed routes.
Invalid IDs now redirect users to the /404 page and don't trigger API requests.

**Added validation for route parameters in:**
- TeamDetail.tsx
- UserProfile.tsx
- FriendChat.tsx

**ID validation to reject:**
- Non-numeric values (abc)
- Negative numbers (-1)
- Non-safe integers / floats (12.34)
- Characters like ";º&/" etc;
- Added early validation to prevent unnecessary API calls when route parameters are invalid.

**Examples:**
The following routes now redirect to /404:
- /team/abc
- /team/-1
- /team/12.34
- /team/NotMemberTeamId
- /profile/xyz
- /friends/chat/7.5

Valid routes continue to work normally

Most cases prevent unnecessary API requests, but only for mallformed URL, the case for '/team/NotMemberTeamId' uses 'GET /teams' to verify if user is a member.

**What is not addressed:**
- Correctly formatted addresses that do not match a DB entry. These return console errors.

##
**Extra:**
- Added email check to the register flow.